### PR TITLE
fix: updated postgre volume mount point path

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U myuser -d mydb || exit 1"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U myuser -d mydb || exit 1"]
       interval: 10s


### PR DESCRIPTION
Postgre 18 has moved the volume mount point from /var/lib/postgresql/data to /var/lib/postgresql
Fixes #122

See line 194 of the Dockerfile of postgres:18-alpine:
https://github.com/docker-library/postgres/blob/22ca5c8d8e4b37bece4d38dbce1a060583b5308a/18/alpine3.22/Dockerfile#L194 
NOTE: in 18+, PGDATA has changed to match the pg_ctlcluster standard directory structure, and the VOLUME has moved from /var/lib/postgresql/data to /var/lib/postgresql

So to prevent a useless volume being created for the postgre docker each time the container is started, accordingly update the mount point of the postgre volume.

After reading the Contributor Guidelines for etherpad-lite:
- there isn't a develop branch for etherpad-go
- it's a bug fix but I'm not sure a regression test is really needed here (I think they are aimed at Typescript/Go bugs, not docker bugs)
- I have no idea how to run a go test suite, and it's probably irrelevant here anyway (works locally and on a VPS, data is persistent) 
- No documentation update needed