### PR TITLE
feat(parity): close protocol and API gaps vs original etherpad

### DIFF
--- a/lib/api/groups/init.go
+++ b/lib/api/groups/init.go
@@ -1,6 +1,8 @@
 package groups
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 
 	"github.com/ether/etherpad-go/lib"
@@ -19,6 +21,22 @@ type CreateGroupPadRequest struct {
 	PadName  string `json:"padName"`
 	Text     string `json:"text"`
 	AuthorId string `json:"authorId"`
+}
+
+// CreateGroupIfNotExistsForRequest represents the request to map an external
+// id to a stable group
+type CreateGroupIfNotExistsForRequest struct {
+	GroupMapper string `json:"groupMapper"`
+}
+
+// GroupListResponse represents a response with all group IDs
+type GroupListResponse struct {
+	GroupIDs []string `json:"groupIDs"`
+}
+
+// PadListResponse represents a response with the pad IDs of a group
+type PadListResponse struct {
+	PadIDs []string `json:"padIDs"`
 }
 
 // CreateGroup godoc
@@ -154,11 +172,112 @@ func CreateGroupPad(store *lib.InitStore) fiber.Handler {
 	}
 }
 
+// CreateGroupIfNotExistsFor godoc
+// @Summary Get or create a group for an external mapper
+// @Description Returns a stable group for the given external mapper id, creating it if necessary. The group id is derived deterministically from the mapper, so the same mapper always maps to the same group.
+// @Tags Groups
+// @Accept json
+// @Produce json
+// @Param request body CreateGroupIfNotExistsForRequest true "External mapper id"
+// @Success 200 {object} GroupIDResponse
+// @Failure 400 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/groups/createIfNotExistsFor [post]
+func CreateGroupIfNotExistsFor(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		var request CreateGroupIfNotExistsForRequest
+		if err := c.Bind().Body(&request); err != nil {
+			return c.Status(400).JSON(errors.InvalidRequestError)
+		}
+		if request.GroupMapper == "" {
+			return c.Status(400).JSON(errors.NewMissingParamError("groupMapper"))
+		}
+
+		// Unlike the original (which stores a mapper2group record), the group
+		// id is derived deterministically from the mapper, which makes the
+		// operation idempotent without extra storage.
+		sum := sha256.Sum256([]byte(request.GroupMapper))
+		groupId := "g." + hex.EncodeToString(sum[:])[:16]
+
+		// SaveGroup is an upsert on every backend, so this is idempotent.
+		if err := store.Store.SaveGroup(groupId); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+
+		return c.JSON(GroupIDResponse{GroupID: groupId})
+	}
+}
+
+// ListAllGroups godoc
+// @Summary List all groups
+// @Description Returns the IDs of all existing groups
+// @Tags Groups
+// @Produce json
+// @Success 200 {object} GroupListResponse
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/groups [get]
+func ListAllGroups(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		groupIds, err := store.Store.GetGroups()
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		return c.JSON(GroupListResponse{GroupIDs: *groupIds})
+	}
+}
+
+// ListGroupPads godoc
+// @Summary List pads of a group
+// @Description Returns the IDs of all pads belonging to a group
+// @Tags Groups
+// @Produce json
+// @Param groupId path string true "Group ID"
+// @Success 200 {object} PadListResponse
+// @Failure 400 {object} errors.Error
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/groups/{groupId}/pads [get]
+func ListGroupPads(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		groupId := c.Params("groupId")
+		if groupId == "" {
+			return c.Status(400).JSON(errors.NewMissingParamError("groupId"))
+		}
+
+		if _, err := store.Store.GetGroup(groupId); err != nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("group does not exist"))
+		}
+
+		// Group membership is derived from the `groupId$padName` id prefix.
+		padIds, err := store.Store.GetPadIds()
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+
+		groupPads := make([]string, 0)
+		if padIds != nil {
+			for _, padId := range *padIds {
+				if strings.HasPrefix(padId, groupId+"$") {
+					groupPads = append(groupPads, padId)
+				}
+			}
+		}
+
+		return c.JSON(PadListResponse{PadIDs: groupPads})
+	}
+}
+
 func Init(store *lib.InitStore) {
-	// Group management
+	// Group management (specific paths before :groupId)
+	store.PrivateAPI.Post("/groups/createIfNotExistsFor", CreateGroupIfNotExistsFor(store))
+	store.PrivateAPI.Get("/groups", ListAllGroups(store))
 	store.PrivateAPI.Post("/groups", CreateGroup(store))
 	store.PrivateAPI.Delete("/groups/:groupId", DeleteGroup(store))
 
 	// Group pads
+	store.PrivateAPI.Get("/groups/:groupId/pads", ListGroupPads(store))
 	store.PrivateAPI.Post("/groups/:groupId/pads", CreateGroupPad(store))
 }

--- a/lib/api/init.go
+++ b/lib/api/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ether/etherpad-go/lib/api/io"
 	"github.com/ether/etherpad-go/lib/api/oidc"
 	"github.com/ether/etherpad-go/lib/api/pad"
+	"github.com/ether/etherpad-go/lib/api/session"
 	"github.com/ether/etherpad-go/lib/api/static"
 	"github.com/ether/etherpad-go/lib/api/stats"
 	swagger2 "github.com/ether/etherpad-go/lib/api/swagger"
@@ -52,6 +53,7 @@ func InitAPI(store *lib.InitStore) *oidc.Authenticator {
 	author.Init(store)
 	pad.Init(store)
 	groups.Init(store)
+	session.Init(store)
 	static.Init(store)
 	io.Init(store)
 	stats.Init(store)

--- a/lib/api/pad/copyMove.go
+++ b/lib/api/pad/copyMove.go
@@ -1,0 +1,314 @@
+package pad
+
+import (
+	"strings"
+
+	"github.com/ether/etherpad-go/lib"
+	errors2 "github.com/ether/etherpad-go/lib/api/errors"
+	utils2 "github.com/ether/etherpad-go/lib/api/utils"
+	db2 "github.com/ether/etherpad-go/lib/models/db"
+	"github.com/gofiber/fiber/v3"
+)
+
+// handlerError carries an HTTP status and the error body to send to the client.
+type handlerError struct {
+	status int
+	body   errors2.Error
+}
+
+// prepareCopyDestination validates the destination pad ID and applies the
+// force semantics of the original Etherpad API: reject when the destination
+// already exists unless force is set, in which case the destination pad is
+// removed first.
+func prepareCopyDestination(initStore *lib.InitStore, destinationID string, force bool) *handlerError {
+	if destinationID == "" {
+		return &handlerError{400, errors2.NewMissingParamError("destinationID")}
+	}
+	if !initStore.PadManager.IsValidPadId(destinationID) {
+		return &handlerError{400, errors2.NewInvalidParamError("destinationID is not a valid pad ID")}
+	}
+
+	exists, err := initStore.PadManager.DoesPadExist(destinationID)
+	if err != nil {
+		return &handlerError{500, errors2.InternalServerError}
+	}
+	if exists != nil && *exists {
+		if !force {
+			return &handlerError{409, errors2.PadAlreadyExistsError}
+		}
+		if err := initStore.PadManager.RemovePad(destinationID); err != nil {
+			return &handlerError{500, errors2.InternalServerError}
+		}
+	}
+	return nil
+}
+
+// copyPadRecords copies the pad record, all revisions and the chat history of
+// sourceID to destinationID using the DataStore primitives. The destination
+// must not exist (callers go through prepareCopyDestination first).
+func copyPadRecords(initStore *lib.InitStore, sourceID string, destinationID string) error {
+	sourceDB, err := initStore.Store.GetPad(sourceID)
+	if err != nil {
+		return err
+	}
+
+	destinationDB := *sourceDB
+	destinationDB.ID = destinationID
+	// Read-only IDs must stay unique per pad; the destination gets its own on demand.
+	destinationDB.ReadOnlyId = nil
+
+	if err := initStore.Store.CreatePad(destinationID, destinationDB); err != nil {
+		return err
+	}
+
+	// Copy the full revision history
+	if sourceDB.Head >= 0 {
+		revisions, err := initStore.Store.GetRevisions(sourceID, 0, sourceDB.Head)
+		if err != nil {
+			return err
+		}
+		for _, rev := range *revisions {
+			pool := db2.RevPool{}
+			if rev.Pool != nil {
+				pool = *rev.Pool
+			}
+			if err := initStore.Store.SaveRevision(
+				destinationID, rev.RevNum, rev.Changeset, rev.AText, pool, rev.AuthorId, rev.Timestamp,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Copy the chat history
+	if sourceDB.ChatHead >= 0 {
+		messages, err := initStore.Store.GetChatsOfPad(sourceID, 0, sourceDB.ChatHead)
+		if err != nil {
+			return err
+		}
+		if messages != nil {
+			for _, msg := range *messages {
+				var timestamp int64
+				if msg.Time != nil {
+					timestamp = *msg.Time
+				}
+				if err := initStore.Store.SaveChatMessage(
+					destinationID, msg.Head, msg.AuthorId, timestamp, msg.Message,
+				); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Make sure the next access loads the freshly written records from the database
+	initStore.PadManager.UnloadPad(destinationID)
+	return nil
+}
+
+// CopyPad godoc
+// @Summary Copy a pad
+// @Description Copies a pad including its full revision and chat history to a new pad. Fails if the destination exists unless force is set.
+// @Tags Pads
+// @Accept json
+// @Produce json
+// @Param padId path string true "Source Pad ID"
+// @Param request body CopyPadRequest true "Destination ID and force flag"
+// @Success 200 {object} PadIDResponse
+// @Failure 400 {object} errors.Error
+// @Failure 404 {object} errors.Error
+// @Failure 409 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/pads/{padId}/copy [post]
+func CopyPad(initStore *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		padId := c.Params("padId")
+		var request CopyPadRequest
+		if err := c.Bind().Body(&request); err != nil {
+			return c.Status(400).JSON(errors2.InvalidRequestError)
+		}
+
+		// Verify source pad exists
+		if _, err := utils2.GetPadSafe(padId, true, nil, nil, initStore.PadManager); err != nil {
+			return c.Status(404).JSON(errors2.PadNotFoundError)
+		}
+
+		if hErr := prepareCopyDestination(initStore, request.DestinationID, request.Force); hErr != nil {
+			return c.Status(hErr.status).JSON(hErr.body)
+		}
+
+		if err := copyPadRecords(initStore, padId, request.DestinationID); err != nil {
+			initStore.Logger.Errorf("Error copying pad %s to %s: %v", padId, request.DestinationID, err)
+			return c.Status(500).JSON(errors2.InternalServerError)
+		}
+
+		return c.JSON(PadIDResponse{
+			PadID: request.DestinationID,
+		})
+	}
+}
+
+// CopyPadWithoutHistory godoc
+// @Summary Copy a pad without history
+// @Description Copies the current text of a pad to a new pad with a single initial revision. Fails if the destination exists unless force is set.
+// @Tags Pads
+// @Accept json
+// @Produce json
+// @Param padId path string true "Source Pad ID"
+// @Param request body CopyPadWithoutHistoryRequest true "Destination ID, force flag and Author ID"
+// @Success 200 {object} PadIDResponse
+// @Failure 400 {object} errors.Error
+// @Failure 404 {object} errors.Error
+// @Failure 409 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/pads/{padId}/copyWithoutHistory [post]
+func CopyPadWithoutHistory(initStore *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		padId := c.Params("padId")
+		var request CopyPadWithoutHistoryRequest
+		if err := c.Bind().Body(&request); err != nil {
+			return c.Status(400).JSON(errors2.InvalidRequestError)
+		}
+
+		// Get the source pad
+		sourcePad, err := utils2.GetPadSafe(padId, true, nil, nil, initStore.PadManager)
+		if err != nil {
+			return c.Status(404).JSON(errors2.PadNotFoundError)
+		}
+
+		if hErr := prepareCopyDestination(initStore, request.DestinationID, request.Force); hErr != nil {
+			return c.Status(hErr.status).JSON(hErr.body)
+		}
+
+		// Creating the destination pad re-adds the trailing newline, so strip it
+		// from the source text first (mirrors the original copyPadWithoutHistory).
+		text := strings.TrimSuffix(sourcePad.Text(), "\n")
+
+		var authorId *string
+		if request.AuthorId != "" {
+			authorId = &request.AuthorId
+		}
+
+		if _, err := initStore.PadManager.GetPad(request.DestinationID, &text, authorId); err != nil {
+			return c.Status(500).JSON(errors2.InternalServerError)
+		}
+
+		return c.JSON(PadIDResponse{
+			PadID: request.DestinationID,
+		})
+	}
+}
+
+// MovePad godoc
+// @Summary Move a pad
+// @Description Moves a pad (copy including history, then remove the source). Fails if the destination exists unless force is set.
+// @Tags Pads
+// @Accept json
+// @Produce json
+// @Param padId path string true "Source Pad ID"
+// @Param request body MovePadRequest true "Destination ID and force flag"
+// @Success 200 {object} PadIDResponse
+// @Failure 400 {object} errors.Error
+// @Failure 404 {object} errors.Error
+// @Failure 409 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/pads/{padId}/move [post]
+func MovePad(initStore *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		padId := c.Params("padId")
+		var request MovePadRequest
+		if err := c.Bind().Body(&request); err != nil {
+			return c.Status(400).JSON(errors2.InvalidRequestError)
+		}
+
+		// Verify source pad exists
+		if _, err := utils2.GetPadSafe(padId, true, nil, nil, initStore.PadManager); err != nil {
+			return c.Status(404).JSON(errors2.PadNotFoundError)
+		}
+
+		if hErr := prepareCopyDestination(initStore, request.DestinationID, request.Force); hErr != nil {
+			return c.Status(hErr.status).JSON(hErr.body)
+		}
+
+		if err := copyPadRecords(initStore, padId, request.DestinationID); err != nil {
+			initStore.Logger.Errorf("Error copying pad %s to %s: %v", padId, request.DestinationID, err)
+			return c.Status(500).JSON(errors2.InternalServerError)
+		}
+
+		// Remove the source pad after a successful copy
+		if err := initStore.PadManager.RemovePad(padId); err != nil {
+			return c.Status(500).JSON(errors2.InternalServerError)
+		}
+
+		return c.JSON(PadIDResponse{
+			PadID: request.DestinationID,
+		})
+	}
+}
+
+// GetPublicStatus godoc
+// @Summary Get public status of a pad
+// @Description Returns whether the pad is marked as public
+// @Tags Pads
+// @Accept json
+// @Produce json
+// @Param padId path string true "Pad ID"
+// @Success 200 {object} PublicStatusResponse
+// @Failure 404 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/pads/{padId}/publicStatus [get]
+func GetPublicStatus(initStore *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		padId := c.Params("padId")
+
+		// Get the pad
+		pad, err := utils2.GetPadSafe(padId, true, nil, nil, initStore.PadManager)
+		if err != nil {
+			return c.Status(404).JSON(errors2.PadNotFoundError)
+		}
+
+		return c.JSON(PublicStatusResponse{
+			PublicStatus: pad.PublicStatus,
+		})
+	}
+}
+
+// SetPublicStatus godoc
+// @Summary Set public status of a pad
+// @Description Marks the pad as public or private and persists the change
+// @Tags Pads
+// @Accept json
+// @Produce json
+// @Param padId path string true "Pad ID"
+// @Param request body PublicStatusRequest true "Public status"
+// @Success 200 {string} string "OK"
+// @Failure 400 {object} errors.Error
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/pads/{padId}/publicStatus [post]
+func SetPublicStatus(initStore *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		padId := c.Params("padId")
+		var request PublicStatusRequest
+		if err := c.Bind().Body(&request); err != nil {
+			return c.Status(400).JSON(errors2.InvalidRequestError)
+		}
+
+		// Get the pad
+		pad, err := utils2.GetPadSafe(padId, true, nil, nil, initStore.PadManager)
+		if err != nil {
+			return c.Status(404).JSON(errors2.PadNotFoundError)
+		}
+
+		pad.PublicStatus = request.PublicStatus
+		if err := pad.Save(); err != nil {
+			return c.Status(500).JSON(errors2.InternalServerError)
+		}
+
+		return c.SendStatus(200)
+	}
+}

--- a/lib/api/pad/init.go
+++ b/lib/api/pad/init.go
@@ -231,6 +231,13 @@ func Init(initStore *lib.InitStore) {
 	initStore.PrivateAPI.Get("/pads/:padId/chatHistory", GetChatHistory(initStore))
 	initStore.PrivateAPI.Post("/pads/:padId/chat", AppendChatMessage(initStore))
 
+	// Copy/move and public status
+	initStore.PrivateAPI.Post("/pads/:padId/copy", CopyPad(initStore))
+	initStore.PrivateAPI.Post("/pads/:padId/copyWithoutHistory", CopyPadWithoutHistory(initStore))
+	initStore.PrivateAPI.Post("/pads/:padId/move", MovePad(initStore))
+	initStore.PrivateAPI.Get("/pads/:padId/publicStatus", GetPublicStatus(initStore))
+	initStore.PrivateAPI.Post("/pads/:padId/publicStatus", SetPublicStatus(initStore))
+
 	// CRUD operations on pad itself (last to avoid conflicts)
 	initStore.PrivateAPI.Post("/pads/:padId", CreatePad(initStore))
 	initStore.PrivateAPI.Delete("/pads/:padId", DeletePad(initStore))

--- a/lib/api/session/init.go
+++ b/lib/api/session/init.go
@@ -1,0 +1,314 @@
+// Package session implements the Etherpad API session endpoints
+// (createSession, getSessionInfo, deleteSession, listSessionsOfGroup,
+// listSessionsOfAuthor from the original HTTP API).
+//
+// API sessions bind an author to a group for access to that group's pads.
+// Like the original (which stores session:*, group2sessions:* and
+// author2sessions:* records in its key-value database), sessions are kept in
+// the generic key-value storage of the DataStore under "apisession:" keys —
+// no dedicated table is needed.
+package session
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ether/etherpad-go/lib"
+	"github.com/ether/etherpad-go/lib/api/errors"
+	"github.com/ether/etherpad-go/lib/utils"
+	"github.com/gofiber/fiber/v3"
+)
+
+const (
+	sessionKeyPrefix = "apisession:"
+	groupKeyPrefix   = "apisessions:group:"
+	authorKeyPrefix  = "apisessions:author:"
+)
+
+// CreateSessionRequest represents the request to create an API session
+type CreateSessionRequest struct {
+	GroupID    string `json:"groupID"`
+	AuthorID   string `json:"authorID"`
+	ValidUntil int64  `json:"validUntil"`
+}
+
+// SessionResponse represents a response with a session ID
+type SessionResponse struct {
+	SessionID string `json:"sessionID"`
+}
+
+// SessionInfoResponse represents the stored data of a session
+type SessionInfoResponse struct {
+	GroupID    string `json:"groupID"`
+	AuthorID   string `json:"authorID"`
+	ValidUntil int64  `json:"validUntil"`
+}
+
+// SessionWithID is a session info including its ID, used in listings
+type SessionWithID struct {
+	SessionID string `json:"sessionID"`
+	SessionInfoResponse
+}
+
+// SessionListResponse represents a list of sessions
+type SessionListResponse struct {
+	Sessions []SessionWithID `json:"sessions"`
+}
+
+func loadSession(store *lib.InitStore, sessionId string) (*SessionInfoResponse, error) {
+	payload, err := store.Store.GetOIDCStorageValue(sessionKeyPrefix + sessionId)
+	if err != nil || payload == nil {
+		return nil, err
+	}
+	var info SessionInfoResponse
+	if err := json.Unmarshal([]byte(*payload), &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func loadIDList(store *lib.InitStore, key string) ([]string, error) {
+	payload, err := store.Store.GetOIDCStorageValue(key)
+	if err != nil || payload == nil {
+		return []string{}, err
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(*payload), &ids); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func saveIDList(store *lib.InitStore, key string, ids []string) error {
+	encoded, err := json.Marshal(ids)
+	if err != nil {
+		return err
+	}
+	return store.Store.SetOIDCStorageValue(key, string(encoded))
+}
+
+func addToIDList(store *lib.InitStore, key string, id string) error {
+	ids, err := loadIDList(store, key)
+	if err != nil {
+		return err
+	}
+	for _, existing := range ids {
+		if existing == id {
+			return nil
+		}
+	}
+	return saveIDList(store, key, append(ids, id))
+}
+
+func removeFromIDList(store *lib.InitStore, key string, id string) error {
+	ids, err := loadIDList(store, key)
+	if err != nil {
+		return err
+	}
+	filtered := make([]string, 0, len(ids))
+	for _, existing := range ids {
+		if existing != id {
+			filtered = append(filtered, existing)
+		}
+	}
+	return saveIDList(store, key, filtered)
+}
+
+// CreateSession godoc
+// @Summary Create an API session
+// @Description Creates a session binding an author to a group until validUntil (unix timestamp in seconds)
+// @Tags Sessions
+// @Accept json
+// @Produce json
+// @Param request body CreateSessionRequest true "Session data"
+// @Success 200 {object} SessionResponse
+// @Failure 400 {object} errors.Error
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/sessions [post]
+func CreateSession(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		var request CreateSessionRequest
+		if err := c.Bind().Body(&request); err != nil {
+			return c.Status(400).JSON(errors.InvalidRequestError)
+		}
+		if request.GroupID == "" {
+			return c.Status(400).JSON(errors.NewMissingParamError("groupID"))
+		}
+		if request.AuthorID == "" {
+			return c.Status(400).JSON(errors.NewMissingParamError("authorID"))
+		}
+		if request.ValidUntil <= time.Now().Unix() {
+			return c.Status(400).JSON(errors.NewInvalidParamError("validUntil is in the past"))
+		}
+
+		if _, err := store.Store.GetGroup(request.GroupID); err != nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("group does not exist"))
+		}
+		if _, err := store.Store.GetAuthor(request.AuthorID); err != nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("author does not exist"))
+		}
+
+		sessionId := "s." + utils.RandomString(16)
+		info := SessionInfoResponse{
+			GroupID:    request.GroupID,
+			AuthorID:   request.AuthorID,
+			ValidUntil: request.ValidUntil,
+		}
+		encoded, err := json.Marshal(info)
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+
+		if err := store.Store.SetOIDCStorageValue(sessionKeyPrefix+sessionId, string(encoded)); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		if err := addToIDList(store, groupKeyPrefix+request.GroupID, sessionId); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		if err := addToIDList(store, authorKeyPrefix+request.AuthorID, sessionId); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+
+		return c.JSON(SessionResponse{SessionID: sessionId})
+	}
+}
+
+// GetSessionInfo godoc
+// @Summary Get session info
+// @Description Returns group, author and expiry of a session
+// @Tags Sessions
+// @Produce json
+// @Param sessionId path string true "Session ID"
+// @Success 200 {object} SessionInfoResponse
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/sessions/{sessionId} [get]
+func GetSessionInfo(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		sessionId := c.Params("sessionId")
+		info, err := loadSession(store, sessionId)
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		if info == nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("session does not exist"))
+		}
+		return c.JSON(info)
+	}
+}
+
+// DeleteSession godoc
+// @Summary Delete a session
+// @Description Deletes an API session
+// @Tags Sessions
+// @Produce json
+// @Param sessionId path string true "Session ID"
+// @Success 200 {string} string "OK"
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/sessions/{sessionId} [delete]
+func DeleteSession(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		sessionId := c.Params("sessionId")
+		info, err := loadSession(store, sessionId)
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		if info == nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("session does not exist"))
+		}
+
+		if err := store.Store.DeleteOIDCStorageValue(sessionKeyPrefix + sessionId); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		if err := removeFromIDList(store, groupKeyPrefix+info.GroupID, sessionId); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		if err := removeFromIDList(store, authorKeyPrefix+info.AuthorID, sessionId); err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+
+		return c.SendStatus(200)
+	}
+}
+
+func listSessions(store *lib.InitStore, key string) ([]SessionWithID, error) {
+	ids, err := loadIDList(store, key)
+	if err != nil {
+		return nil, err
+	}
+	sessions := make([]SessionWithID, 0, len(ids))
+	for _, id := range ids {
+		info, err := loadSession(store, id)
+		if err != nil {
+			return nil, err
+		}
+		if info == nil {
+			continue
+		}
+		sessions = append(sessions, SessionWithID{SessionID: id, SessionInfoResponse: *info})
+	}
+	return sessions, nil
+}
+
+// ListSessionsOfGroup godoc
+// @Summary List sessions of a group
+// @Description Returns all sessions of a group
+// @Tags Sessions
+// @Produce json
+// @Param groupId path string true "Group ID"
+// @Success 200 {object} SessionListResponse
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/groups/{groupId}/sessions [get]
+func ListSessionsOfGroup(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		groupId := c.Params("groupId")
+		if _, err := store.Store.GetGroup(groupId); err != nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("group does not exist"))
+		}
+		sessions, err := listSessions(store, groupKeyPrefix+groupId)
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		return c.JSON(SessionListResponse{Sessions: sessions})
+	}
+}
+
+// ListSessionsOfAuthor godoc
+// @Summary List sessions of an author
+// @Description Returns all sessions of an author
+// @Tags Sessions
+// @Produce json
+// @Param authorId path string true "Author ID"
+// @Success 200 {object} SessionListResponse
+// @Failure 404 {object} errors.Error
+// @Failure 500 {object} errors.Error
+// @Security BearerAuth
+// @Router /admin/api/authors/{authorId}/sessions [get]
+func ListSessionsOfAuthor(store *lib.InitStore) fiber.Handler {
+	return func(c fiber.Ctx) error {
+		authorId := c.Params("authorId")
+		if _, err := store.Store.GetAuthor(authorId); err != nil {
+			return c.Status(404).JSON(errors.NewInvalidParamError("author does not exist"))
+		}
+		sessions, err := listSessions(store, authorKeyPrefix+authorId)
+		if err != nil {
+			return c.Status(500).JSON(errors.InternalServerError)
+		}
+		return c.JSON(SessionListResponse{Sessions: sessions})
+	}
+}
+
+func Init(store *lib.InitStore) {
+	store.PrivateAPI.Post("/sessions", CreateSession(store))
+	store.PrivateAPI.Get("/sessions/:sessionId", GetSessionInfo(store))
+	store.PrivateAPI.Delete("/sessions/:sessionId", DeleteSession(store))
+	store.PrivateAPI.Get("/groups/:groupId/sessions", ListSessionsOfGroup(store))
+	store.PrivateAPI.Get("/authors/:authorId/sessions", ListSessionsOfAuthor(store))
+}

--- a/lib/changeset/changeset.go
+++ b/lib/changeset/changeset.go
@@ -377,9 +377,8 @@ func Follow(c string, rebasedChangeset string, reverseInsertOrder bool, pool *ap
 			}
 
 			if whichToDo == 1 {
-				err := chars1.Skip(op1.Chars)
-				if err != nil {
-					panic(err)
+				if err := chars1.Skip(op1.Chars); err != nil {
+					return nil, err
 				}
 				opOut.OpCode = "="
 				opOut.Lines = op1.Lines
@@ -780,11 +779,12 @@ func Inverse(cs string, lines []string, alines []string, pool *apool.APool) (*st
 
 	builder := NewBuilder(unpacked.NewLen)
 
-	consumeAttribRuns := func(numChars int, callback func(length int, attribs string, endsLine bool)) {
+	consumeAttribRuns := func(numChars int, callback func(length int, attribs string, endsLine bool)) error {
 		if curLineOps == nil || curLineOpsLine != curLine {
-			curLineOps, err = DeserializeOps(alinesGet(curLine))
-			if err != nil {
-				panic(err)
+			var deserializeErr error
+			curLineOps, deserializeErr = DeserializeOps(alinesGet(curLine))
+			if deserializeErr != nil {
+				return deserializeErr
 			}
 			curLineOpsNext = 0
 			curLineOpsLine = curLine
@@ -806,9 +806,10 @@ func Inverse(cs string, lines []string, alines []string, pool *apool.APool) (*st
 				curChar = 0
 				curLineOpsLine = curLine
 				curLineNextOp = NewOp(nil)
-				curLineOps, err = DeserializeOps(alinesGet(curLine))
-				if err != nil {
-					panic(err)
+				var deserializeErr error
+				curLineOps, deserializeErr = DeserializeOps(alinesGet(curLine))
+				if deserializeErr != nil {
+					return deserializeErr
 				}
 				curLineOpsNext = 0
 			}
@@ -831,19 +832,21 @@ func Inverse(cs string, lines []string, alines []string, pool *apool.APool) (*st
 			curLine++
 			curChar = 0
 		}
+		return nil
 	}
 
-	skip := func(n int, l int) {
+	skip := func(n int, l int) error {
 		if l > 0 {
 			curLine += l
 			curChar = 0
 			curLineOps = nil
 			curLineNextOp = NewOp(nil)
 		} else if curLineOps != nil && curLineOpsLine == curLine {
-			consumeAttribRuns(n, func(int, string, bool) {})
+			return consumeAttribRuns(n, func(int, string, bool) {})
 		} else {
 			curChar += n
 		}
+		return nil
 	}
 
 	nextText := func(numChars int) string {
@@ -901,7 +904,7 @@ func Inverse(cs string, lines []string, alines []string, pool *apool.APool) (*st
 					}
 					return backAttribs.String()
 				})
-				consumeAttribRuns(csOp.Chars, func(length int, attribs string, endsLine bool) {
+				if err := consumeAttribRuns(csOp.Chars, func(length int, attribs string, endsLine bool) {
 					lines := 0
 					if endsLine {
 						lines = 1
@@ -910,9 +913,13 @@ func Inverse(cs string, lines []string, alines []string, pool *apool.APool) (*st
 					builder.Keep(length, lines, KeepArgs{
 						stringAttribs: &undoArgs,
 					}, nil)
-				})
+				}); err != nil {
+					return nil, err
+				}
 			} else {
-				skip(csOp.Chars, csOp.Lines)
+				if err := skip(csOp.Chars, csOp.Lines); err != nil {
+					return nil, err
+				}
 				emptyString := ""
 				builder.Keep(csOp.Chars, csOp.Lines, KeepArgs{
 					stringAttribs: &emptyString,
@@ -923,12 +930,14 @@ func Inverse(cs string, lines []string, alines []string, pool *apool.APool) (*st
 		} else if csOp.OpCode == "-" {
 			textBank := nextText(csOp.Chars)
 			textBankIndex := 0
-			consumeAttribRuns(csOp.Chars, func(length int, attribs string, endsLine bool) {
+			if err := consumeAttribRuns(csOp.Chars, func(length int, attribs string, endsLine bool) {
 				builder.Insert(utils.RuneSlice(textBank, textBankIndex, textBankIndex+length), KeepArgs{
 					stringAttribs: &attribs,
 				}, nil)
 				textBankIndex += length
-			})
+			}); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -1183,8 +1192,14 @@ func DeserializeOps(ops string) (*[]Op, error) {
 }
 
 func Compose(cs1 string, cs2 string, pool *apool.APool) (*string, error) {
-	var unpacked1, _ = Unpack(cs1)
-	var unpacked2, _ = Unpack(cs2)
+	var unpacked1, err1 = Unpack(cs1)
+	if err1 != nil {
+		return nil, err1
+	}
+	var unpacked2, err2 = Unpack(cs2)
+	if err2 != nil {
+		return nil, err2
+	}
 	var len1 = unpacked1.OldLen
 	var len2 = unpacked1.NewLen
 
@@ -1210,7 +1225,7 @@ func Compose(cs1 string, cs2 string, pool *apool.APool) (*string, error) {
 		var opOut, err = SlicerZipperFunc(op1, op2, pool)
 
 		if err != nil {
-			panic(fmt.Sprintf("Error in SlicerZipperFunc: %v", err))
+			return nil, err
 		}
 
 		if opOut.OpCode == "+" {

--- a/lib/changeset/malformed_input_test.go
+++ b/lib/changeset/malformed_input_test.go
@@ -1,0 +1,78 @@
+package changeset
+
+import (
+	"testing"
+
+	"github.com/ether/etherpad-go/lib/apool"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression tests for panic sites in changeset.go. Malformed input that
+// slips past CheckRep must surface as an error, never crash the server.
+
+// Follow used to panic when the char bank of the first changeset was shorter
+// than its '+' ops claimed (chars1.Skip failed inside the ApplyZip callback).
+func TestFollow_ShortCharBankReturnsError(t *testing.T) {
+	pool := apool.NewAPool()
+	// "+5" claims five inserted chars but the bank only holds three.
+	cs1 := "Z:0>5+5$abc"
+	cs2 := "Z:0>1+1$x"
+
+	assert.NotPanics(t, func() {
+		_, err := Follow(cs1, cs2, false, &pool)
+		assert.Error(t, err)
+	})
+}
+
+// Inverse used to panic when an attribute line (alines) could not be
+// deserialized (DeserializeOps error inside consumeAttribRuns).
+func TestInverse_MalformedAlinesReturnsError(t *testing.T) {
+	pool := apool.NewAPool()
+	// Valid changeset removing one char, but the attribute line is garbage.
+	cs := "Z:2<1-1$"
+	lines := []string{"ab"}
+	alines := []string{"!"}
+
+	assert.NotPanics(t, func() {
+		_, err := Inverse(cs, lines, alines, &pool)
+		assert.Error(t, err)
+	})
+}
+
+// Inverse used to panic when advancing to the next attribute line yielded a
+// malformed alines entry (second DeserializeOps call inside consumeAttribRuns).
+func TestInverse_MalformedSecondAlineReturnsError(t *testing.T) {
+	pool := apool.NewAPool()
+	// Remove three chars spanning two lines; second attribute line is garbage.
+	cs := "Z:4<3|1-3$"
+	lines := []string{"a\n", "b\n"}
+	alines := []string{"|1+2", "!"}
+
+	assert.NotPanics(t, func() {
+		_, err := Inverse(cs, lines, alines, &pool)
+		assert.Error(t, err)
+	})
+}
+
+// Compose used to panic when SlicerZipperFunc rejected inconsistent ops
+// (here: a keep op that claims more lines than chars).
+func TestCompose_InvalidOpsReturnError(t *testing.T) {
+	pool := apool.NewAPool()
+	cs1 := "Z:5>0|2=1$"
+	cs2 := "Z:5>0=1$"
+
+	assert.NotPanics(t, func() {
+		_, err := Compose(cs1, cs2, &pool)
+		assert.Error(t, err)
+	})
+}
+
+// Compose ignored Unpack errors entirely; garbage input must return an error.
+func TestCompose_GarbageInputReturnsError(t *testing.T) {
+	pool := apool.NewAPool()
+
+	assert.NotPanics(t, func() {
+		_, err := Compose("garbage", "Z:0>0$", &pool)
+		assert.Error(t, err)
+	})
+}

--- a/lib/db/DataStore.go
+++ b/lib/db/DataStore.go
@@ -61,6 +61,7 @@ type SessionMethods interface {
 
 type GroupMethods interface {
 	GetGroup(groupId string) (*string, error)
+	GetGroups() (*[]string, error)
 	SaveGroup(groupId string) error
 	RemoveGroup(groupId string) error
 }

--- a/lib/db/MemoryDataStore.go
+++ b/lib/db/MemoryDataStore.go
@@ -512,6 +512,14 @@ func (m *MemoryDataStore) GetGroup(groupId string) (*string, error) {
 	return &group, nil
 }
 
+func (m *MemoryDataStore) GetGroups() (*[]string, error) {
+	groups := make([]string, 0, len(m.groupStore))
+	for id := range m.groupStore {
+		groups = append(groups, id)
+	}
+	return &groups, nil
+}
+
 // ============== SESSION METHODS ==============
 
 func (m *MemoryDataStore) GetSessionById(sessionID string) (*session2.Session, error) {

--- a/lib/db/MySQLDB.go
+++ b/lib/db/MySQLDB.go
@@ -796,6 +796,35 @@ func (d MysqlDB) RemoveGroup(groupId string) error {
 	return err
 }
 
+func (d MysqlDB) GetGroups() (*[]string, error) {
+	resultedSQL, args, err := mysql.
+		Select("id").
+		From("groupPadGroup").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := d.sqlDB.Query(resultedSQL, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	groups := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		groups = append(groups, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return &groups, nil
+}
+
 func (d MysqlDB) GetGroup(groupId string) (*string, error) {
 	resultedSQL, args, err := mysql.
 		Select("id").
@@ -857,7 +886,7 @@ func (d MysqlDB) SetSessionById(sessionID string, session session2.Session) erro
 	retrievedSql, inserts, err := mysql.Insert("sessionstorage").
 		Columns("id", "originalMaxAge", "expires", "secure", "httpOnly", "path", "sameSite", "connections").
 		Values(sessionID, session.OriginalMaxAge, session.Expires, session.Secure,
-			session.HttpOnly, session.Path, session.SameSite, "").
+			session.HttpOnly, session.Path, session.SameSite, session.Connections).
 		Suffix(`ON DUPLICATE KEY UPDATE 
 			originalMaxAge = VALUES(originalMaxAge), 
 			expires = VALUES(expires), 

--- a/lib/db/PostgresDB.go
+++ b/lib/db/PostgresDB.go
@@ -619,6 +619,28 @@ func (d PostgresDB) RemoveGroup(groupId string) error {
 	return err
 }
 
+func (d PostgresDB) GetGroups() (*[]string, error) {
+	ctx := context.Background()
+	rows, err := d.pool.Query(ctx, `SELECT id FROM "grouppadgroup"`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	groups := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		groups = append(groups, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return &groups, nil
+}
+
 func (d PostgresDB) GetGroup(groupId string) (*string, error) {
 	ctx := context.Background()
 	var foundGroup string
@@ -672,7 +694,7 @@ func (d PostgresDB) SetSessionById(sessionID string, session session2.Session) e
              connections = EXCLUDED.connections,
              updated_at = NOW()`,
 		sessionID, session.OriginalMaxAge, session.Expires, session.Secure,
-		session.HttpOnly, session.Path, session.SameSite, "")
+		session.HttpOnly, session.Path, session.SameSite, session.Connections)
 	return err
 }
 

--- a/lib/db/SQLiteDB.go
+++ b/lib/db/SQLiteDB.go
@@ -812,6 +812,35 @@ func (d SQLiteDB) RemoveGroup(groupId string) error {
 	return err
 }
 
+func (d SQLiteDB) GetGroups() (*[]string, error) {
+	resultedSQL, args, err := sq.
+		Select("id").
+		From("groupPadGroup").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := d.sqlDB.Query(resultedSQL, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	groups := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		groups = append(groups, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return &groups, nil
+}
+
 func (d SQLiteDB) GetGroup(groupId string) (*string, error) {
 	resultedSQL, args, err := sq.
 		Select("id").
@@ -873,7 +902,7 @@ func (d SQLiteDB) SetSessionById(sessionID string, session session2.Session) err
 	retrievedSql, inserts, err := sq.Insert("sessionstorage").
 		Columns("id", "originalMaxAge", "expires", "secure", "httpOnly", "path", "sameSite", "connections").
 		Values(sessionID, session.OriginalMaxAge, session.Expires, session.Secure,
-			session.HttpOnly, session.Path, session.SameSite, "").
+			session.HttpOnly, session.Path, session.SameSite, session.Connections).
 		Suffix(`ON CONFLICT(id) DO UPDATE SET 
 			originalMaxAge = excluded.originalMaxAge, 
 			expires = excluded.expires, 

--- a/lib/models/pad/Pad.go
+++ b/lib/models/pad/Pad.go
@@ -25,7 +25,7 @@ import (
 var padRegex *regexp.Regexp
 
 func init() {
-	padRegex, _ = regexp.Compile(`^(g\.[A-Za-z0-9]{16})?[^ \t\r\n\f\v$]{1,50}$`)
+	padRegex, _ = regexp.Compile(`^(g\.[A-Za-z0-9]{16}\$)?[^ \t\r\n\f\v$]{1,50}$`)
 }
 
 func IsValidPadId(padID string) bool {
@@ -272,19 +272,14 @@ func (p *Pad) getKeyRevisionAText(revNum int) (*apool.AText, error) {
 }
 
 func (p *Pad) Remove() error {
-	padId := p.Id
-	// Kick session is done in ws package to avoid circular import
-	if utils.RuneIndex(padId, "$") >= 0 {
-		indexOfDollar := utils.RuneIndex(padId, "$")
-		groupId := padId[0:indexOfDollar]
-		groupVal, err := p.db.GetGroup(groupId)
-		if err != nil {
-			return err
-		}
-		// TODO remove pad from group pads list
-		println("Removing group:", groupVal)
-	}
-	// Actual code was moved to padManager to avoid circular import
+	// Kick session is done in ws package to avoid circular import.
+	//
+	// Group membership needs no cleanup here: unlike the original Etherpad,
+	// which keeps a group2pads mapping, this implementation derives a
+	// group's pad list from the `groupId$padName` ID prefix, so deleting
+	// the pad record is sufficient.
+	//
+	// Actual deletion code was moved to padManager to avoid circular import.
 	return nil
 }
 
@@ -555,7 +550,6 @@ func (p *Pad) AppendRevision(cs string, authorId *string) (*int, error) {
 	var newAText, err = changeset.ApplyToAText(cs, p.AText, p.Pool)
 
 	if err != nil {
-		println("Error applying changeset to atext:", err.Error())
 		return &p.Head, errors.New("Error applying changeset to atext " + err.Error())
 	}
 
@@ -578,6 +572,24 @@ func (p *Pad) AppendRevision(cs string, authorId *string) (*int, error) {
 
 	// Save pad
 	p.Save()
+
+	// padRev.authorId has a foreign key on globalAuthor. The reserved system
+	// author (used for unattributed API/plugin writes, upstream #7773) is
+	// never created through the normal author flows, so make sure its row
+	// exists before saving a revision attributed to it.
+	if authorId != nil && *authorId == SystemAuthorId {
+		if _, getErr := p.db.GetAuthor(SystemAuthorId); getErr != nil {
+			systemName := "System"
+			if saveErr := p.db.SaveAuthor(db2.AuthorDB{
+				ID:        SystemAuthorId,
+				Name:      &systemName,
+				ColorId:   "#808080",
+				Timestamp: time.Now().Unix(),
+			}); saveErr != nil {
+				return nil, errors.New("Error ensuring system author exists " + saveErr.Error())
+			}
+		}
+	}
 
 	var poolToUse apool.APool
 	var atextToUse apool.AText

--- a/lib/models/ws/ClientMessage.go
+++ b/lib/models/ws/ClientMessage.go
@@ -1,0 +1,28 @@
+package ws
+
+// ClientMessage is the COLLABROOM CLIENT_MESSAGE family from the original
+// protocol. The payload type selects the sub-message: "suggestUserName"
+// relays a name suggestion to an unnamed user, "padoptions" distributes
+// pad-wide settings.
+type ClientMessage struct {
+	Event string            `json:"event"`
+	Data  ClientMessageData `json:"data"`
+}
+
+type ClientMessageData struct {
+	Component string                `json:"component"`
+	Type      string                `json:"type"`
+	Data      ClientMessageDataData `json:"data"`
+}
+
+type ClientMessageDataData struct {
+	Type    string               `json:"type"`
+	Payload ClientMessagePayload `json:"payload"`
+}
+
+type ClientMessagePayload struct {
+	Type      string         `json:"type"`
+	NewName   string         `json:"newName,omitempty"`
+	UnnamedId string         `json:"unnamedId,omitempty"`
+	Options   map[string]any `json:"options,omitempty"`
+}

--- a/lib/pad/padManager.go
+++ b/lib/pad/padManager.go
@@ -63,7 +63,7 @@ func (l *List) GetPads() []string {
 var padRegex *regexp.Regexp
 
 func init() {
-	padRegex, _ = regexp.Compile(`^(g\.[A-Za-z0-9]{16})?[^ \t\r\n\f\v$]{1,50}$`)
+	padRegex, _ = regexp.Compile(`^(g\.[A-Za-z0-9]{16}\$)?[^ \t\r\n\f\v$]{1,50}$`)
 }
 
 type GlobalPadCache struct {

--- a/lib/server/server.go
+++ b/lib/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ether/etherpad-go/lib/pad"
 	"github.com/ether/etherpad-go/lib/plugins"
 	"github.com/ether/etherpad-go/lib/plugins/interfaces"
+	epsession "github.com/ether/etherpad-go/lib/session"
 	settings2 "github.com/ether/etherpad-go/lib/settings"
 	"github.com/ether/etherpad-go/lib/utils"
 	"github.com/ether/etherpad-go/lib/ws"
@@ -97,6 +98,7 @@ func InitServer(setupLogger *zap.SugaredLogger, uiAssets embed.FS, pluginAssets 
 	var cookieStore = session.NewStore(session.Config{
 		CookieSameSite: settings.Cookie.SameSite,
 		IdleTimeout:    time.Duration(settings.Cookie.SessionLifetime),
+		Storage:        epsession.NewSessionDatabase(&dataStore),
 	})
 
 	hooks.ExpressPreSession(app, uiAssets)

--- a/lib/session/SessionDatabase.go
+++ b/lib/session/SessionDatabase.go
@@ -1,36 +1,157 @@
 package session
 
 import (
+	"context"
+	"encoding/base64"
 	"time"
 
 	"github.com/ether/etherpad-go/lib/db"
+	sessionmodel "github.com/ether/etherpad-go/lib/models/session"
+	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/log"
 )
 
+// Database is a fiber.Storage adapter backed by the DataStore's
+// `sessionstorage` table so that HTTP sessions survive server restarts.
+//
+// The opaque session payload handed over by fiber is base64-encoded and
+// stored in the session record's Connections field; the expiration instant
+// is stored as an RFC3339 string in the Expires field (an empty Expires
+// means the entry never expires). Expired entries are treated as missing on
+// Get and lazily purged from the DataStore.
 type Database struct {
+	store db.DataStore
 }
 
+// Compile-time check that Database satisfies fiber.Storage.
+var _ fiber.Storage = Database{}
+
+// GetWithContext gets the value for the given key. `nil, nil` is returned
+// when the key does not exist or the entry has expired.
+func (s Database) GetWithContext(_ context.Context, key string) ([]byte, error) {
+	return s.Get(key)
+}
+
+// Get gets the value for the given key. `nil, nil` is returned when the key
+// does not exist or the entry has expired.
 func (s Database) Get(key string) ([]byte, error) {
-	return nil, nil
+	if key == "" {
+		return nil, nil
+	}
+
+	record, err := s.store.GetSessionById(key)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil {
+		return nil, nil
+	}
+
+	if record.Expires != "" {
+		expires, err := time.Parse(time.RFC3339, record.Expires)
+		if err != nil {
+			// Unreadable expiry: treat the record as corrupt and drop it.
+			s.purge(key)
+			return nil, nil
+		}
+		if !expires.After(time.Now()) {
+			s.purge(key)
+			return nil, nil
+		}
+	}
+
+	if record.Connections == "" {
+		// No payload stored; treat as missing.
+		return nil, nil
+	}
+
+	val, err := base64.StdEncoding.DecodeString(record.Connections)
+	if err != nil {
+		// Corrupt payload: drop the record and report the key as missing.
+		s.purge(key)
+		return nil, nil
+	}
+	return val, nil
 }
 
+// SetWithContext stores the given value for the given key along with an
+// expiration duration. An exp of 0 means no expiration.
+func (s Database) SetWithContext(_ context.Context, key string, val []byte, exp time.Duration) error {
+	return s.Set(key, val, exp)
+}
+
+// Set stores the given value for the given key along with an expiration
+// duration. An exp of 0 means no expiration. Empty key or value is ignored
+// without an error, as required by the fiber.Storage contract.
 func (s Database) Set(key string, val []byte, exp time.Duration) error {
-	//TODO implement me
-	return nil
+	if key == "" || len(val) == 0 {
+		return nil
+	}
+
+	var expires string
+	if exp > 0 {
+		expires = time.Now().Add(exp).UTC().Format(time.RFC3339)
+	}
+
+	return s.store.SetSessionById(key, sessionmodel.Session{
+		Id:             key,
+		OriginalMaxAge: int(exp.Milliseconds()),
+		Expires:        expires,
+		Connections:    base64.StdEncoding.EncodeToString(val),
+	})
 }
 
+// DeleteWithContext deletes the value for the given key. It returns no error
+// if the storage does not contain the key.
+func (s Database) DeleteWithContext(_ context.Context, key string) error {
+	return s.Delete(key)
+}
+
+// Delete deletes the value for the given key. It returns no error if the
+// storage does not contain the key.
 func (s Database) Delete(key string) error {
+	if key == "" {
+		return nil
+	}
 
-	return nil
+	record, err := s.store.GetSessionById(key)
+	if err != nil {
+		return err
+	}
+	if record == nil {
+		// Key does not exist; per the fiber.Storage contract this is not an
+		// error.
+		return nil
+	}
+	return s.store.RemoveSessionById(key)
 }
 
+// ResetWithContext resets the storage and deletes all keys.
+func (s Database) ResetWithContext(_ context.Context) error {
+	return s.Reset()
+}
+
+// Reset is a no-op: the DataStore interface offers no way to enumerate or
+// bulk-delete session records. Fiber only calls Reset via an explicit
+// store.Reset(), which Etherpad never does.
 func (s Database) Reset() error {
 	return nil
 }
 
+// Close is a no-op; the underlying DataStore's lifecycle is managed by the
+// server, not by the session storage adapter.
 func (s Database) Close() error {
 	return nil
 }
 
+// purge removes a stale or corrupt session record, logging (but otherwise
+// ignoring) failures since Get must still report the key as missing.
+func (s Database) purge(key string) {
+	if err := s.store.RemoveSessionById(key); err != nil {
+		log.Warnf("session: failed to purge expired session %s: %v", key, err)
+	}
+}
+
 func NewSessionDatabase(db *db.DataStore) Database {
-	return Database{}
+	return Database{store: *db}
 }

--- a/lib/session/SessionDatabase_test.go
+++ b/lib/session/SessionDatabase_test.go
@@ -1,0 +1,230 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ether/etherpad-go/lib/db"
+)
+
+func newTestSessionDatabase(t *testing.T) (Database, db.DataStore) {
+	t.Helper()
+	var store db.DataStore = db.NewMemoryDataStore()
+	return NewSessionDatabase(&store), store
+}
+
+func TestSessionDatabaseSetGetRoundtrip(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	want := []byte(`{"user":"alice","admin":true}`)
+	if err := sessionDB.Set("sid-1", want, 0); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	got, err := sessionDB.Get("sid-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Get returned %q, want %q", got, want)
+	}
+}
+
+func TestSessionDatabaseGetMissingKeyReturnsNilNil(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	got, err := sessionDB.Get("does-not-exist")
+	if err != nil {
+		t.Fatalf("Get of missing key returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Get of missing key returned %q, want nil", got)
+	}
+}
+
+func TestSessionDatabaseSetOverwritesExistingValue(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	if err := sessionDB.Set("sid-1", []byte("first"), 0); err != nil {
+		t.Fatalf("first Set returned error: %v", err)
+	}
+	if err := sessionDB.Set("sid-1", []byte("second"), 0); err != nil {
+		t.Fatalf("second Set returned error: %v", err)
+	}
+
+	got, err := sessionDB.Get("sid-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if string(got) != "second" {
+		t.Fatalf("Get returned %q, want %q", got, "second")
+	}
+}
+
+func TestSessionDatabaseDeleteRemovesKey(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	if err := sessionDB.Set("sid-1", []byte("value"), 0); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+	if err := sessionDB.Delete("sid-1"); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+
+	got, err := sessionDB.Get("sid-1")
+	if err != nil {
+		t.Fatalf("Get after Delete returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Get after Delete returned %q, want nil", got)
+	}
+}
+
+func TestSessionDatabaseDeleteMissingKeyIsNoError(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	if err := sessionDB.Delete("does-not-exist"); err != nil {
+		t.Fatalf("Delete of missing key returned error: %v", err)
+	}
+}
+
+func TestSessionDatabasePersistsAcrossInstances(t *testing.T) {
+	// Simulates a server restart: a new Database instance backed by the
+	// same DataStore must still see the session.
+	var store db.DataStore = db.NewMemoryDataStore()
+	first := NewSessionDatabase(&store)
+
+	want := []byte("persisted-session-data")
+	if err := first.Set("sid-restart", want, time.Hour); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	second := NewSessionDatabase(&store)
+	got, err := second.Get("sid-restart")
+	if err != nil {
+		t.Fatalf("Get on new instance returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Get on new instance returned %q, want %q", got, want)
+	}
+}
+
+func TestSessionDatabaseExpiredEntryIsTreatedAsMissing(t *testing.T) {
+	sessionDB, store := newTestSessionDatabase(t)
+
+	if err := sessionDB.Set("sid-exp", []byte("ephemeral"), time.Millisecond); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	got, err := sessionDB.Get("sid-exp")
+	if err != nil {
+		t.Fatalf("Get of expired key returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Get of expired key returned %q, want nil", got)
+	}
+
+	// The expired record should have been purged from the DataStore.
+	record, err := store.GetSessionById("sid-exp")
+	if err != nil {
+		t.Fatalf("GetSessionById returned error: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expired session record was not removed from the DataStore: %+v", record)
+	}
+}
+
+func TestSessionDatabaseUnexpiredEntryIsReturned(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	want := []byte("still-alive")
+	if err := sessionDB.Set("sid-alive", want, time.Hour); err != nil {
+		t.Fatalf("Set returned error: %v", err)
+	}
+
+	got, err := sessionDB.Get("sid-alive")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Get returned %q, want %q", got, want)
+	}
+}
+
+func TestSessionDatabaseSetIgnoresEmptyKeyAndValue(t *testing.T) {
+	// Per the fiber.Storage contract, empty key or value must be ignored
+	// without an error.
+	sessionDB, store := newTestSessionDatabase(t)
+
+	if err := sessionDB.Set("", []byte("value"), 0); err != nil {
+		t.Fatalf("Set with empty key returned error: %v", err)
+	}
+	if err := sessionDB.Set("sid-empty", nil, 0); err != nil {
+		t.Fatalf("Set with nil value returned error: %v", err)
+	}
+	if err := sessionDB.Set("sid-empty", []byte{}, 0); err != nil {
+		t.Fatalf("Set with empty value returned error: %v", err)
+	}
+
+	got, err := sessionDB.Get("sid-empty")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Get returned %q, want nil", got)
+	}
+
+	record, err := store.GetSessionById("")
+	if err != nil {
+		t.Fatalf("GetSessionById returned error: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("empty key was stored in the DataStore: %+v", record)
+	}
+}
+
+func TestSessionDatabaseWithContextVariants(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+	ctx := context.Background()
+
+	want := []byte("ctx-value")
+	if err := sessionDB.SetWithContext(ctx, "sid-ctx", want, 0); err != nil {
+		t.Fatalf("SetWithContext returned error: %v", err)
+	}
+
+	got, err := sessionDB.GetWithContext(ctx, "sid-ctx")
+	if err != nil {
+		t.Fatalf("GetWithContext returned error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("GetWithContext returned %q, want %q", got, want)
+	}
+
+	if err := sessionDB.DeleteWithContext(ctx, "sid-ctx"); err != nil {
+		t.Fatalf("DeleteWithContext returned error: %v", err)
+	}
+	got, err = sessionDB.GetWithContext(ctx, "sid-ctx")
+	if err != nil {
+		t.Fatalf("GetWithContext after delete returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetWithContext after delete returned %q, want nil", got)
+	}
+
+	if err := sessionDB.ResetWithContext(ctx); err != nil {
+		t.Fatalf("ResetWithContext returned error: %v", err)
+	}
+}
+
+func TestSessionDatabaseResetAndCloseAreSafe(t *testing.T) {
+	sessionDB, _ := newTestSessionDatabase(t)
+
+	if err := sessionDB.Reset(); err != nil {
+		t.Fatalf("Reset returned error: %v", err)
+	}
+	if err := sessionDB.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+}

--- a/lib/test/api/groups/groups_api_test.go
+++ b/lib/test/api/groups/groups_api_test.go
@@ -43,6 +43,18 @@ func TestGroupsAPI(t *testing.T) {
 			Name: "CreateGroupPad group not found",
 			Test: testCreateGroupPadGroupNotFound,
 		},
+		testutils.TestRunConfig{
+			Name: "CreateGroupIfNotExistsFor is idempotent",
+			Test: testCreateGroupIfNotExistsFor,
+		},
+		testutils.TestRunConfig{
+			Name: "ListAllGroups returns groups",
+			Test: testListAllGroups,
+		},
+		testutils.TestRunConfig{
+			Name: "ListGroupPads returns pads of group",
+			Test: testListGroupPads,
+		},
 	)
 
 	defer testDb.StartTestDBHandler()
@@ -50,9 +62,9 @@ func TestGroupsAPI(t *testing.T) {
 
 // Helper to create a group
 func createTestGroup(t *testing.T, tsStore testutils.TestDataStore) string {
-	err := tsStore.DS.SaveGroup("g.testgroup123456")
+	err := tsStore.DS.SaveGroup("g.testgroup1234567")
 	assert.NoError(t, err)
-	return "g.testgroup123456"
+	return "g.testgroup1234567"
 }
 
 // ========== Create Group ==========
@@ -124,15 +136,12 @@ func testCreateGroupPadSuccess(t *testing.T, tsStore testutils.TestDataStore) {
 	resp, err := initStore.C.Test(req)
 
 	assert.NoError(t, err)
-	// Note: The current PadManager regex does not allow $ in pad IDs
-	// Group pads (format: g.xxx$padname) may fail validation
-	// This is a known limitation that may need to be addressed in PadManager
-	if resp.StatusCode == 200 {
-		var response map[string]string
-		respBody, _ := io.ReadAll(resp.Body)
-		_ = json.Unmarshal(respBody, &response)
-		assert.Contains(t, response["padID"], groupId)
-	}
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var response map[string]string
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(respBody, &response)
+	assert.Contains(t, response["padID"], groupId)
 }
 
 func testCreateGroupPadInvalidName(t *testing.T, tsStore testutils.TestDataStore) {
@@ -170,4 +179,93 @@ func testCreateGroupPadGroupNotFound(t *testing.T, tsStore testutils.TestDataSto
 
 	assert.NoError(t, err)
 	assert.Equal(t, 404, resp.StatusCode)
+}
+
+// ========== Create Group If Not Exists For ==========
+
+func testCreateGroupIfNotExistsFor(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	groups.Init(initStore)
+
+	body, _ := json.Marshal(groups.CreateGroupIfNotExistsForRequest{GroupMapper: "my-external-id"})
+	req := httptest.NewRequest("POST", "/admin/api/groups/createIfNotExistsFor", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := initStore.C.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var first groups.GroupIDResponse
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(respBody, &first)
+	assert.Equal(t, "g.", first.GroupID[:2])
+
+	// Same mapper returns the same group
+	req2 := httptest.NewRequest("POST", "/admin/api/groups/createIfNotExistsFor", bytes.NewBuffer(body))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := initStore.C.Test(req2)
+	assert.NoError(t, err)
+	var second groups.GroupIDResponse
+	respBody2, _ := io.ReadAll(resp2.Body)
+	_ = json.Unmarshal(respBody2, &second)
+	assert.Equal(t, first.GroupID, second.GroupID)
+
+	// Group actually exists
+	_, err = tsStore.DS.GetGroup(first.GroupID)
+	assert.NoError(t, err)
+
+	// Missing mapper is a 400
+	req3 := httptest.NewRequest("POST", "/admin/api/groups/createIfNotExistsFor", bytes.NewBuffer([]byte(`{}`)))
+	req3.Header.Set("Content-Type", "application/json")
+	resp3, _ := initStore.C.Test(req3)
+	assert.Equal(t, 400, resp3.StatusCode)
+}
+
+// ========== List All Groups ==========
+
+func testListAllGroups(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	groups.Init(initStore)
+
+	assert.NoError(t, tsStore.DS.SaveGroup("g.listgroupsAAAAAA"))
+	assert.NoError(t, tsStore.DS.SaveGroup("g.listgroupsBBBBBB"))
+
+	req := httptest.NewRequest("GET", "/admin/api/groups", nil)
+	resp, err := initStore.C.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var response groups.GroupListResponse
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &response)
+	assert.Contains(t, response.GroupIDs, "g.listgroupsAAAAAA")
+	assert.Contains(t, response.GroupIDs, "g.listgroupsBBBBBB")
+}
+
+// ========== List Group Pads ==========
+
+func testListGroupPads(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	groups.Init(initStore)
+
+	// pad ids require a g.<16 alphanumeric chars> group prefix
+	groupId := "g.listpads12345678"[:18]
+	assert.NoError(t, tsStore.DS.SaveGroup(groupId))
+	padId := groupId + "$mypad"
+	_, err := tsStore.PadManager.GetPad(padId, nil, nil)
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/admin/api/groups/"+groupId+"/pads", nil)
+	resp, err := initStore.C.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var response groups.PadListResponse
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &response)
+	assert.Contains(t, response.PadIDs, padId)
+
+	// Unknown group returns 404
+	req2 := httptest.NewRequest("GET", "/admin/api/groups/g.doesnotexist1234/pads", nil)
+	resp2, _ := initStore.C.Test(req2)
+	assert.Equal(t, 404, resp2.StatusCode)
 }

--- a/lib/test/api/pad/pad_api_test.go
+++ b/lib/test/api/pad/pad_api_test.go
@@ -143,6 +143,54 @@ func TestPadAPI(t *testing.T) {
 			Name: "CheckToken returns 200",
 			Test: testCheckToken,
 		},
+		// Copy pad
+		testutils.TestRunConfig{
+			Name: "CopyPad copies pad with history",
+			Test: testCopyPadSuccess,
+		},
+		testutils.TestRunConfig{
+			Name: "CopyPad source not found returns 404",
+			Test: testCopyPadSourceNotFound,
+		},
+		testutils.TestRunConfig{
+			Name: "CopyPad destination exists without force returns 409",
+			Test: testCopyPadDestinationExistsNoForce,
+		},
+		testutils.TestRunConfig{
+			Name: "CopyPad with force overwrites destination",
+			Test: testCopyPadForceOverwrites,
+		},
+		// Copy pad without history
+		testutils.TestRunConfig{
+			Name: "CopyPadWithoutHistory copies only current text",
+			Test: testCopyPadWithoutHistorySuccess,
+		},
+		testutils.TestRunConfig{
+			Name: "CopyPadWithoutHistory destination exists without force returns 409",
+			Test: testCopyPadWithoutHistoryDestinationExistsNoForce,
+		},
+		// Move pad
+		testutils.TestRunConfig{
+			Name: "MovePad moves pad and removes source",
+			Test: testMovePadSuccess,
+		},
+		testutils.TestRunConfig{
+			Name: "MovePad destination exists without force returns 409",
+			Test: testMovePadDestinationExistsNoForce,
+		},
+		// Public status
+		testutils.TestRunConfig{
+			Name: "GetPublicStatus defaults to false",
+			Test: testGetPublicStatusDefault,
+		},
+		testutils.TestRunConfig{
+			Name: "SetPublicStatus persists across pad reload",
+			Test: testSetPublicStatusPersists,
+		},
+		testutils.TestRunConfig{
+			Name: "GetPublicStatus pad not found returns 404",
+			Test: testGetPublicStatusNotFound,
+		},
 	)
 
 	defer testDb.StartTestDBHandler()
@@ -698,6 +746,269 @@ func testGetPadUsersCount(t *testing.T, tsStore testutils.TestDataStore) {
 	_ = json.Unmarshal(body, &response)
 
 	assert.Equal(t, 0, response.PadUsersCount)
+}
+
+// ========== Copy Pad ==========
+
+// helper to POST a copy/move-style request body to the given URL
+func postPadOperation(t *testing.T, tsStore testutils.TestDataStore, url string, destinationID string, force bool) (int, []byte) {
+	t.Helper()
+	initStore := tsStore.ToInitStore()
+
+	reqBody := pad.CopyPadRequest{
+		DestinationID: destinationID,
+		Force:         force,
+	}
+	body, err := json.Marshal(reqBody)
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := initStore.C.Test(req)
+	assert.NoError(t, err)
+
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, respBody
+}
+
+// helper to fetch the text of a pad through the API
+func getPadTextViaAPI(t *testing.T, tsStore testutils.TestDataStore, padId string) (int, string) {
+	t.Helper()
+	initStore := tsStore.ToInitStore()
+
+	req := httptest.NewRequest("GET", "/admin/api/pads/"+padId+"/text", nil)
+	resp, err := initStore.C.Test(req)
+	assert.NoError(t, err)
+
+	var response pad.TextResponse
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &response)
+	return resp.StatusCode, response.Text
+}
+
+func testCopyPadSuccess(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	text := "Copy me\n"
+	createTestPad(t, tsStore, "copysource", text)
+
+	// Add a second revision so we can verify history is copied
+	srcPad, err := tsStore.PadManager.GetPad("copysource", nil, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, srcPad.SetText("Copy me v2", nil))
+	sourceHead := srcPad.Head
+
+	status, respBody := postPadOperation(t, tsStore, "/admin/api/pads/copysource/copy", "copydest", false)
+	assert.Equal(t, 200, status, "response body: %s", string(respBody))
+
+	var response pad.PadIDResponse
+	_ = json.Unmarshal(respBody, &response)
+	assert.Equal(t, "copydest", response.PadID)
+
+	// Destination has the same text
+	textStatus, destText := getPadTextViaAPI(t, tsStore, "copydest")
+	assert.Equal(t, 200, textStatus)
+	assert.Contains(t, destText, "Copy me v2")
+
+	// Destination has the same revision history
+	destPad, err := tsStore.PadManager.GetPad("copydest", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, sourceHead, destPad.Head)
+
+	// Source pad still exists
+	srcStatus, srcText := getPadTextViaAPI(t, tsStore, "copysource")
+	assert.Equal(t, 200, srcStatus)
+	assert.Contains(t, srcText, "Copy me v2")
+}
+
+func testCopyPadSourceNotFound(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	status, _ := postPadOperation(t, tsStore, "/admin/api/pads/nosuchsource/copy", "copydest2", false)
+	assert.Equal(t, 404, status)
+}
+
+func testCopyPadDestinationExistsNoForce(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "copysrc3", "Source\n")
+	createTestPad(t, tsStore, "copydst3", "Existing destination\n")
+
+	status, _ := postPadOperation(t, tsStore, "/admin/api/pads/copysrc3/copy", "copydst3", false)
+	assert.Equal(t, 409, status)
+
+	// Destination is untouched
+	textStatus, destText := getPadTextViaAPI(t, tsStore, "copydst3")
+	assert.Equal(t, 200, textStatus)
+	assert.Contains(t, destText, "Existing destination")
+}
+
+func testCopyPadForceOverwrites(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "copysrc4", "Force source\n")
+	createTestPad(t, tsStore, "copydst4", "Old destination\n")
+
+	status, respBody := postPadOperation(t, tsStore, "/admin/api/pads/copysrc4/copy", "copydst4", true)
+	assert.Equal(t, 200, status, "response body: %s", string(respBody))
+
+	textStatus, destText := getPadTextViaAPI(t, tsStore, "copydst4")
+	assert.Equal(t, 200, textStatus)
+	assert.Contains(t, destText, "Force source")
+	assert.NotContains(t, destText, "Old destination")
+}
+
+// ========== Copy Pad Without History ==========
+
+func testCopyPadWithoutHistorySuccess(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "nohistsrc", "No history source\n")
+
+	// Add a second revision; the copy must not include it
+	srcPad, err := tsStore.PadManager.GetPad("nohistsrc", nil, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, srcPad.SetText("No history source v2", nil))
+	assert.True(t, srcPad.Head > 0)
+
+	status, respBody := postPadOperation(t, tsStore, "/admin/api/pads/nohistsrc/copyWithoutHistory", "nohistdst", false)
+	assert.Equal(t, 200, status, "response body: %s", string(respBody))
+
+	var response pad.PadIDResponse
+	_ = json.Unmarshal(respBody, &response)
+	assert.Equal(t, "nohistdst", response.PadID)
+
+	// Destination has the current text but only the initial revision
+	textStatus, destText := getPadTextViaAPI(t, tsStore, "nohistdst")
+	assert.Equal(t, 200, textStatus)
+	assert.Contains(t, destText, "No history source v2")
+
+	destPad, err := tsStore.PadManager.GetPad("nohistdst", nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, destPad.Head)
+}
+
+func testCopyPadWithoutHistoryDestinationExistsNoForce(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "nohistsrc2", "Source\n")
+	createTestPad(t, tsStore, "nohistdst2", "Existing destination\n")
+
+	status, _ := postPadOperation(t, tsStore, "/admin/api/pads/nohistsrc2/copyWithoutHistory", "nohistdst2", false)
+	assert.Equal(t, 409, status)
+}
+
+// ========== Move Pad ==========
+
+func testMovePadSuccess(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "movesource", "Move me\n")
+
+	status, respBody := postPadOperation(t, tsStore, "/admin/api/pads/movesource/move", "movedest", false)
+	assert.Equal(t, 200, status, "response body: %s", string(respBody))
+
+	var response pad.PadIDResponse
+	_ = json.Unmarshal(respBody, &response)
+	assert.Equal(t, "movedest", response.PadID)
+
+	// Destination has the text
+	textStatus, destText := getPadTextViaAPI(t, tsStore, "movedest")
+	assert.Equal(t, 200, textStatus)
+	assert.Contains(t, destText, "Move me")
+
+	// Source pad is gone
+	srcStatus, _ := getPadTextViaAPI(t, tsStore, "movesource")
+	assert.Equal(t, 404, srcStatus)
+}
+
+func testMovePadDestinationExistsNoForce(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "movesrc2", "Move source\n")
+	createTestPad(t, tsStore, "movedst2", "Existing destination\n")
+
+	status, _ := postPadOperation(t, tsStore, "/admin/api/pads/movesrc2/move", "movedst2", false)
+	assert.Equal(t, 409, status)
+
+	// Source pad still exists
+	srcStatus, srcText := getPadTextViaAPI(t, tsStore, "movesrc2")
+	assert.Equal(t, 200, srcStatus)
+	assert.Contains(t, srcText, "Move source")
+}
+
+// ========== Public Status ==========
+
+func testGetPublicStatusDefault(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "publicpad", "Public status test\n")
+
+	req := httptest.NewRequest("GET", "/admin/api/pads/publicpad/publicStatus", nil)
+	resp, err := initStore.C.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var response pad.PublicStatusResponse
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &response)
+
+	assert.False(t, response.PublicStatus)
+}
+
+func testSetPublicStatusPersists(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	createTestPad(t, tsStore, "publicpad2", "Public status test\n")
+
+	reqBody := pad.PublicStatusRequest{
+		PublicStatus: true,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest("POST", "/admin/api/pads/publicpad2/publicStatus", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := initStore.C.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Evict the pad from the manager cache so the next read comes from the database
+	tsStore.PadManager.UnloadPad("publicpad2")
+
+	req = httptest.NewRequest("GET", "/admin/api/pads/publicpad2/publicStatus", nil)
+	resp, err = initStore.C.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var response pad.PublicStatusResponse
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(respBody, &response)
+
+	assert.True(t, response.PublicStatus)
+}
+
+func testGetPublicStatusNotFound(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	pad.Init(initStore)
+
+	req := httptest.NewRequest("GET", "/admin/api/pads/nosuchpublicpad/publicStatus", nil)
+	resp, err := initStore.C.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 404, resp.StatusCode)
 }
 
 // ========== Check Token ==========

--- a/lib/test/api/session/session_api_test.go
+++ b/lib/test/api/session/session_api_test.go
@@ -1,0 +1,203 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ether/etherpad-go/lib/api/session"
+	"github.com/ether/etherpad-go/lib/test/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionAPI(t *testing.T) {
+	testDb := testutils.NewTestDBHandler(t)
+
+	testDb.AddTests(
+		testutils.TestRunConfig{
+			Name: "CreateSession and GetSessionInfo roundtrip",
+			Test: testCreateAndGetSession,
+		},
+		testutils.TestRunConfig{
+			Name: "CreateSession validates group, author and validUntil",
+			Test: testCreateSessionValidation,
+		},
+		testutils.TestRunConfig{
+			Name: "DeleteSession removes the session",
+			Test: testDeleteSession,
+		},
+		testutils.TestRunConfig{
+			Name: "ListSessions of group and author",
+			Test: testListSessions,
+		},
+	)
+
+	defer testDb.StartTestDBHandler()
+}
+
+func setupGroupAndAuthor(t *testing.T, tsStore testutils.TestDataStore) (string, string) {
+	t.Helper()
+	groupId := "g.sessiongrp123456"
+	require.NoError(t, tsStore.DS.SaveGroup(groupId))
+	author, err := tsStore.AuthorManager.CreateAuthor(nil)
+	require.NoError(t, err)
+	return groupId, author.Id
+}
+
+func createSessionViaAPI(t *testing.T, tsStore testutils.TestDataStore, groupId string, authorId string, validUntil int64) (int, session.SessionResponse) {
+	t.Helper()
+	initStore := tsStore.ToInitStore()
+
+	body, _ := json.Marshal(session.CreateSessionRequest{
+		GroupID:    groupId,
+		AuthorID:   authorId,
+		ValidUntil: validUntil,
+	})
+	req := httptest.NewRequest("POST", "/admin/api/sessions", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := initStore.C.Test(req)
+	require.NoError(t, err)
+
+	var response session.SessionResponse
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(respBody, &response)
+	return resp.StatusCode, response
+}
+
+func testCreateAndGetSession(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	session.Init(initStore)
+
+	groupId, authorId := setupGroupAndAuthor(t, tsStore)
+	validUntil := time.Now().Unix() + 3600
+
+	status, created := createSessionViaAPI(t, tsStore, groupId, authorId, validUntil)
+	assert.Equal(t, 200, status)
+	require.NotEmpty(t, created.SessionID)
+	assert.Equal(t, "s.", created.SessionID[:2])
+
+	// Info roundtrip
+	req := httptest.NewRequest("GET", "/admin/api/sessions/"+created.SessionID, nil)
+	resp, err := initStore.C.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var info session.SessionInfoResponse
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &info)
+	assert.Equal(t, groupId, info.GroupID)
+	assert.Equal(t, authorId, info.AuthorID)
+	assert.Equal(t, validUntil, info.ValidUntil)
+
+	// Unknown session is a 404
+	reqMissing := httptest.NewRequest("GET", "/admin/api/sessions/s.doesnotexist12345", nil)
+	respMissing, _ := initStore.C.Test(reqMissing)
+	assert.Equal(t, 404, respMissing.StatusCode)
+}
+
+func testCreateSessionValidation(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	session.Init(initStore)
+
+	groupId, authorId := setupGroupAndAuthor(t, tsStore)
+	future := time.Now().Unix() + 3600
+
+	// Unknown group
+	status, _ := createSessionViaAPI(t, tsStore, "g.unknowngroup1234", authorId, future)
+	assert.Equal(t, 404, status)
+
+	// Unknown author
+	status, _ = createSessionViaAPI(t, tsStore, groupId, "a.unknownauthor1234", future)
+	assert.Equal(t, 404, status)
+
+	// validUntil in the past
+	status, _ = createSessionViaAPI(t, tsStore, groupId, authorId, time.Now().Unix()-10)
+	assert.Equal(t, 400, status)
+}
+
+func testDeleteSession(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	session.Init(initStore)
+
+	groupId, authorId := setupGroupAndAuthor(t, tsStore)
+	status, created := createSessionViaAPI(t, tsStore, groupId, authorId, time.Now().Unix()+3600)
+	require.Equal(t, 200, status)
+
+	req := httptest.NewRequest("DELETE", "/admin/api/sessions/"+created.SessionID, nil)
+	resp, err := initStore.C.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Now gone
+	reqInfo := httptest.NewRequest("GET", "/admin/api/sessions/"+created.SessionID, nil)
+	respInfo, _ := initStore.C.Test(reqInfo)
+	assert.Equal(t, 404, respInfo.StatusCode)
+
+	// Deleting again is a 404
+	reqAgain := httptest.NewRequest("DELETE", "/admin/api/sessions/"+created.SessionID, nil)
+	respAgain, _ := initStore.C.Test(reqAgain)
+	assert.Equal(t, 404, respAgain.StatusCode)
+}
+
+func testListSessions(t *testing.T, tsStore testutils.TestDataStore) {
+	initStore := tsStore.ToInitStore()
+	session.Init(initStore)
+
+	groupId, authorId := setupGroupAndAuthor(t, tsStore)
+	future := time.Now().Unix() + 3600
+
+	status, first := createSessionViaAPI(t, tsStore, groupId, authorId, future)
+	require.Equal(t, 200, status)
+	status, second := createSessionViaAPI(t, tsStore, groupId, authorId, future)
+	require.Equal(t, 200, status)
+
+	// By group
+	req := httptest.NewRequest("GET", "/admin/api/groups/"+groupId+"/sessions", nil)
+	resp, err := initStore.C.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var groupSessions session.SessionListResponse
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &groupSessions)
+	sessionIds := make([]string, 0)
+	for _, s := range groupSessions.Sessions {
+		sessionIds = append(sessionIds, s.SessionID)
+	}
+	assert.Contains(t, sessionIds, first.SessionID)
+	assert.Contains(t, sessionIds, second.SessionID)
+
+	// By author
+	reqAuthor := httptest.NewRequest("GET", "/admin/api/authors/"+authorId+"/sessions", nil)
+	respAuthor, err := initStore.C.Test(reqAuthor)
+	require.NoError(t, err)
+	assert.Equal(t, 200, respAuthor.StatusCode)
+
+	var authorSessions session.SessionListResponse
+	bodyAuthor, _ := io.ReadAll(respAuthor.Body)
+	_ = json.Unmarshal(bodyAuthor, &authorSessions)
+	sessionIds = sessionIds[:0]
+	for _, s := range authorSessions.Sessions {
+		sessionIds = append(sessionIds, s.SessionID)
+	}
+	assert.Contains(t, sessionIds, first.SessionID)
+	assert.Contains(t, sessionIds, second.SessionID)
+
+	// Deleting a session removes it from the listings
+	reqDel := httptest.NewRequest("DELETE", "/admin/api/sessions/"+first.SessionID, nil)
+	respDel, err := initStore.C.Test(reqDel)
+	require.NoError(t, err)
+	require.Equal(t, 200, respDel.StatusCode)
+
+	respList2, _ := initStore.C.Test(httptest.NewRequest("GET", "/admin/api/groups/"+groupId+"/sessions", nil))
+	var groupSessions2 session.SessionListResponse
+	bodyList2, _ := io.ReadAll(respList2.Body)
+	_ = json.Unmarshal(bodyList2, &groupSessions2)
+	for _, s := range groupSessions2.Sessions {
+		assert.NotEqual(t, first.SessionID, s.SessionID)
+	}
+}

--- a/lib/test/ws/pad_message_handler_test.go
+++ b/lib/test/ws/pad_message_handler_test.go
@@ -2,9 +2,12 @@ package ws
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ether/etherpad-go/lib/apool"
+	"github.com/ether/etherpad-go/lib/changeset"
 	"github.com/ether/etherpad-go/lib/models/ws"
 	"github.com/ether/etherpad-go/lib/test/testutils"
 	libws "github.com/ether/etherpad-go/lib/ws"
@@ -152,6 +155,18 @@ func TestPadMessageHandler_AllMethods(t *testing.T) {
 		testutils.TestRunConfig{
 			Name: "HandleMessage with UserChange on readonly rejects",
 			Test: testHandleMessageUserChangeReadonly,
+		},
+		testutils.TestRunConfig{
+			Name: "HandleMessage with invalid changeset sends badChangeset disconnect",
+			Test: testUserChangeInvalidChangesetSendsBadChangeset,
+		},
+		testutils.TestRunConfig{
+			Name: "CorrectMarkersInPad removes misplaced line markers",
+			Test: testCorrectMarkersInPad,
+		},
+		testutils.TestRunConfig{
+			Name: "CLIENT_MESSAGE suggestUserName is relayed to target author",
+			Test: testClientMessageSuggestUserName,
 		},
 		testutils.TestRunConfig{
 			Name: "HandleMessage with unknown type",
@@ -1650,6 +1665,99 @@ func testHandleMessageUserChangeReadonly(t *testing.T, ds testutils.TestDataStor
 	assert.Equal(t, headBefore, retrievedPad.Head, "Readonly pad should not have new revisions")
 }
 
+// drainClientMessages drains all messages currently buffered on the client's
+// Send channel and returns them as strings.
+func drainClientMessages(client *libws.Client) []string {
+	var messages []string
+	for {
+		select {
+		case msg := <-client.Send:
+			messages = append(messages, string(msg))
+		default:
+			return messages
+		}
+	}
+}
+
+// testUserChangeInvalidChangesetSendsBadChangeset tests that an invalid
+// changeset submitted via USER_CHANGES results in a {disconnect: "badChangeset"}
+// message being sent to the client (mirrors the original PadMessageHandler.ts
+// catch-all in handleUserChanges) and that the pad head stays unchanged.
+func testUserChangeInvalidChangesetSendsBadChangeset(t *testing.T, ds testutils.TestDataStore) {
+	padId := "test-pad-bad-changeset"
+	token := "test-token-bad-changeset"
+
+	// The session author must match the author granted by the security
+	// manager for the token, otherwise HandleMessage sends a
+	// {disconnect: "rejected"} userdup message and never queues the change.
+	tokenAuthor, err := ds.AuthorManager.GetAuthor4Token(token)
+	require.NoError(t, err)
+	authorId := tokenAuthor.Id
+
+	// Create the pad
+	_, err = ds.PadManager.GetPad(padId, nil, &authorId)
+	require.NoError(t, err)
+
+	mockConn := libws.NewActualMockWebSocketconn()
+	sessionId := "test-session-bad-changeset"
+
+	client := createTestClient(ds.Hub, sessionId, padId, mockConn)
+	defer func() {
+		delete(ds.Hub.Clients, client)
+	}()
+
+	// Initialize a writable (non-readonly) session
+	ds.PadMessageHandler.SessionStore.InitSessionForTest(sessionId)
+	ds.PadMessageHandler.SessionStore.AddHandleClientInformationForTest(sessionId, padId, token)
+	ds.PadMessageHandler.SessionStore.SetAuthorForTest(sessionId, authorId)
+	ds.PadMessageHandler.SessionStore.SetPadIdForTest(sessionId, padId)
+	ds.PadMessageHandler.SessionStore.AddPadReadOnlyIdsForTest(sessionId, padId, "readonly-id", false)
+
+	// Get pad revision before
+	retrievedPad, err := ds.PadManager.GetPad(padId, nil, &authorId)
+	require.NoError(t, err)
+	headBefore := retrievedPad.Head
+
+	// Create USER_CHANGES message with an invalid changeset: declared insert
+	// length (>3) does not match the ops (+2) — CheckRep must reject it.
+	userChange := ws.UserChange{
+		Event: "message",
+		Data: ws.UserChangeData{
+			Component: "pad",
+			Type:      "USER_CHANGES",
+			Data: ws.UserChangeDataData{
+				Apool: ws.UserChangeDataDataApool{
+					NumToAttrib: map[int][]string{},
+					NextNum:     0,
+				},
+				BaseRev:   0,
+				Changeset: "Z:1>3+2$abc",
+			},
+		},
+	}
+
+	initStore := ds.ToInitStore()
+	ds.PadMessageHandler.HandleMessage(userChange, client, initStore.RetrievedSettings, ds.Logger)
+
+	// USER_CHANGES processing is async via the per-pad queue
+	time.Sleep(200 * time.Millisecond)
+
+	messages := drainClientMessages(client)
+	foundBadChangeset := false
+	for _, msg := range messages {
+		if strings.Contains(msg, `"disconnect":"badChangeset"`) {
+			foundBadChangeset = true
+		}
+	}
+	assert.True(t, foundBadChangeset,
+		"Client should receive a disconnect badChangeset message, got: %v", messages)
+
+	// Verify pad was NOT changed
+	retrievedPad, err = ds.PadManager.GetPad(padId, nil, &authorId)
+	require.NoError(t, err)
+	assert.Equal(t, headBefore, retrievedPad.Head, "Invalid changeset must not create a new revision")
+}
+
 // testHandleMessageUnknownType tests HandleMessage with unknown message type
 func testHandleMessageUnknownType(t *testing.T, ds testutils.TestDataStore) {
 	padId := "test-pad-handle-unknown"
@@ -1732,4 +1840,94 @@ func testHandleMessageNoSession(t *testing.T, ds testutils.TestDataStore) {
 
 	// Verify no message was sent (no session should cause early return)
 	assert.Equal(t, initialMsgCount, len(mockConn.Data), "No message should be sent without session")
+}
+
+// testCorrectMarkersInPad tests that misplaced line markers (e.g. list
+// bullets not at a line start) are detected and a correction changeset is
+// produced, mirroring the original's _correctMarkersInPad.
+func testCorrectMarkersInPad(t *testing.T, ds testutils.TestDataStore) {
+	pool := apool.NewAPool()
+	pool.PutAttrib(apool.Attribute{Key: "list", Value: "bullet1"}, nil)
+
+	// Marker on the char at offset 1 ("b") — not at a line start.
+	atextBad := apool.AText{Text: "ab\n", Attribs: "+1*0+1|1+1"}
+	correction := ds.PadMessageHandler.CorrectMarkersInPadForTest(atextBad, pool)
+	require.NotNil(t, correction, "misplaced marker must produce a correction changeset")
+
+	// Applying the correction must remove the marked char.
+	corrected, err := changeset.ApplyToText(*correction, atextBad.Text)
+	require.NoError(t, err)
+	assert.Equal(t, "a\n", *corrected)
+
+	// Marker at the start of a line is fine — no correction.
+	atextOk := apool.AText{Text: "ab\n", Attribs: "*0+1+1|1+1"}
+	assert.Nil(t, ds.PadMessageHandler.CorrectMarkersInPadForTest(atextOk, pool))
+}
+
+// testClientMessageSuggestUserName tests that a CLIENT_MESSAGE with
+// suggestUserName payload is relayed only to the sockets of the unnamed
+// target author, mirroring the original handleSuggestUserName.
+func testClientMessageSuggestUserName(t *testing.T, ds testutils.TestDataStore) {
+	padId := "test-pad-suggest-username"
+	targetAuthorId, err := setupPadAndAuthor(t, ds, padId, "TargetUser")
+	require.NoError(t, err)
+	senderAuthor, err := ds.AuthorManager.CreateAuthor(nil)
+	require.NoError(t, err)
+
+	targetConn := libws.NewActualMockWebSocketconn()
+	senderConn := libws.NewActualMockWebSocketconn()
+	targetClient := createTestClient(ds.Hub, "suggest-target-session", padId, targetConn)
+	senderClient := createTestClient(ds.Hub, "suggest-sender-session", padId, senderConn)
+	defer func() {
+		delete(ds.Hub.Clients, targetClient)
+		delete(ds.Hub.Clients, senderClient)
+	}()
+
+	for sessionId, authorId := range map[string]string{
+		"suggest-target-session": targetAuthorId,
+		"suggest-sender-session": senderAuthor.Id,
+	} {
+		// HandleMessage resolves the author from the token via CheckAccess,
+		// so the token must map to the session's author.
+		token := "token-" + sessionId
+		require.NoError(t, ds.DS.SetAuthorByToken(token, authorId))
+		ds.PadMessageHandler.SessionStore.InitSessionForTest(sessionId)
+		ds.PadMessageHandler.SessionStore.AddHandleClientInformationForTest(sessionId, padId, token)
+		ds.PadMessageHandler.SessionStore.SetAuthorForTest(sessionId, authorId)
+		ds.PadMessageHandler.SessionStore.SetPadIdForTest(sessionId, padId)
+		ds.PadMessageHandler.SessionStore.AddPadReadOnlyIdsForTest(sessionId, padId, "readonly-id", false)
+	}
+
+	clientMessage := ws.ClientMessage{
+		Event: "message",
+		Data: ws.ClientMessageData{
+			Component: "pad",
+			Type:      "COLLABROOM",
+			Data: ws.ClientMessageDataData{
+				Type: "CLIENT_MESSAGE",
+				Payload: ws.ClientMessagePayload{
+					Type:      "suggestUserName",
+					NewName:   "Alice",
+					UnnamedId: targetAuthorId,
+				},
+			},
+		},
+	}
+
+	initStore := ds.ToInitStore()
+	ds.PadMessageHandler.HandleMessage(clientMessage, senderClient, initStore.RetrievedSettings, ds.Logger)
+	time.Sleep(100 * time.Millisecond)
+
+	targetMessages := drainClientMessages(targetClient)
+	found := false
+	for _, msg := range targetMessages {
+		if strings.Contains(msg, "suggestUserName") && strings.Contains(msg, "Alice") {
+			found = true
+		}
+	}
+	assert.True(t, found, "target client must receive the suggestUserName message, got: %v", targetMessages)
+
+	for _, msg := range drainClientMessages(senderClient) {
+		assert.NotContains(t, msg, "suggestUserName", "sender must not receive the suggestUserName relay")
+	}
 }

--- a/lib/test/ws/test_helpers.go
+++ b/lib/test/ws/test_helpers.go
@@ -2,32 +2,46 @@ package ws
 
 import (
 	"sync"
-	"time"
 
 	libws "github.com/ether/etherpad-go/lib/ws"
 )
 
-// mockWritePump simulates the writePump goroutine for tests.
-// It reads from the client's Send channel and writes to the MockWebSocket.
-func mockWritePump(client *libws.Client, mockConn *libws.MockWebSocketConn, wg *sync.WaitGroup) {
+// mockPump simulates the writePump goroutine for tests. Handlers send
+// messages synchronously (SafeSend into the buffered Send channel), so by
+// the time a test calls Wait() every message is already buffered. Wait()
+// closes the channel, lets the pump drain it deterministically and then
+// installs a fresh Send channel so the same client can be reused with a new
+// pump. This replaces an earlier idle-timeout based pump that flaked when a
+// handler (e.g. bulkDeletePads on a slow MySQL container) took longer than
+// the timeout before responding.
+type mockPump struct {
+	wg     sync.WaitGroup
+	client *libws.Client
+	once   sync.Once
+}
+
+// Wait drains and stops the pump. Safe to call multiple times.
+func (p *mockPump) Wait() {
+	p.once.Do(func() {
+		close(p.client.Send)
+		p.wg.Wait()
+		p.client.Send = make(chan []byte, 256)
+	})
+}
+
+func mockWritePump(send <-chan []byte, mockConn *libws.MockWebSocketConn, wg *sync.WaitGroup) {
 	defer wg.Done()
-	for {
-		select {
-		case message, ok := <-client.Send:
-			if !ok {
-				return
-			}
-			mockConn.WriteMessage(1, message)
-		case <-time.After(500 * time.Millisecond):
-			return
-		}
+	for message := range send {
+		mockConn.WriteMessage(1, message)
 	}
 }
 
-// startMockWritePump starts a mock write pump and returns a WaitGroup to wait for completion
-func startMockWritePump(client *libws.Client, mockConn *libws.MockWebSocketConn) *sync.WaitGroup {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go mockWritePump(client, mockConn, &wg)
-	return &wg
+// startMockWritePump starts a mock write pump. Call Wait() on the returned
+// pump after the (synchronous) handler call to drain the client's Send
+// channel into the MockWebSocketConn.
+func startMockWritePump(client *libws.Client, mockConn *libws.MockWebSocketConn) *mockPump {
+	p := &mockPump{client: client}
+	p.wg.Add(1)
+	go mockWritePump(client.Send, mockConn, &p.wg)
+	return p
 }

--- a/lib/ws/AdminMessageHandler.go
+++ b/lib/ws/AdminMessageHandler.go
@@ -98,7 +98,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 		{
 			var padCreateData admin.PadCreateData
 			if err := json.Unmarshal(message.Data, &padCreateData); err != nil {
-				println("Error unmarshalling padCreate data:", err.Error())
+				h.Logger.Warn("Error unmarshalling padCreate data:", err.Error())
 			}
 			padExists, err := h.padManager.DoesPadExist(padCreateData.PadName)
 			if err != nil {
@@ -115,7 +115,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 				resp[1] = errorMessage
 				responseBytes, err := json.Marshal(resp)
 				if err != nil {
-					println("Error marshalling response:", err.Error())
+					h.Logger.Warn("Error marshalling response:", err.Error())
 					return
 				}
 
@@ -136,7 +136,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 
 				responseBytes, err := json.Marshal(resp)
 				if err != nil {
-					println("Error marshalling response:", err.Error())
+					h.Logger.Warn("Error marshalling response:", err.Error())
 					return
 				}
 				c.SafeSend(responseBytes)
@@ -147,12 +147,12 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 		{
 			var padLoadData admin.PadLoadData
 			if err := json.Unmarshal(message.Data, &padLoadData); err != nil {
-				println("Error unmarshalling padLoad data:", err.Error())
+				h.Logger.Warn("Error unmarshalling padLoad data:", err.Error())
 				return
 			}
 			dbPads, err := h.store.QueryPad(padLoadData.Offset, padLoadData.Limit, padLoadData.SortBy, padLoadData.Ascending, padLoadData.Pattern)
 			if err != nil {
-				println("Error querying pads:", err.Error())
+				h.Logger.Warn("Error querying pads:", err.Error())
 				return
 			}
 
@@ -175,7 +175,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 				return
 			}
 			c.SafeSend(responseBytes)
@@ -217,7 +217,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 				return
 			}
 			c.SafeSend(responseBytes)
@@ -226,7 +226,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 		{
 			var adminMessage admin.ShoutMessageRequest
 			if err := json.Unmarshal(message.Data, &adminMessage); err != nil {
-				println("Error unmarshalling shout data:", err.Error())
+				h.Logger.Warn("Error unmarshalling shout data:", err.Error())
 				return
 			}
 			padShoutData := admin.ShoutMessageResponse{
@@ -244,7 +244,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 			resp[1] = padShoutData
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 				return
 			}
 
@@ -259,7 +259,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 		{
 			var padDeleteData admin.PadDeleteData
 			if err := json.Unmarshal(message.Data, &padDeleteData); err != nil {
-				println("Error unmarshalling padDelete data:", err.Error())
+				h.Logger.Warn("Error unmarshalling padDelete data:", err.Error())
 				return
 			}
 
@@ -276,7 +276,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 				return
 			}
 			c.SafeSend(responseBytes)
@@ -289,7 +289,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 			}
 			var padDeleteData admin.PadCleanupData
 			if err := json.Unmarshal(message.Data, &padDeleteData); err != nil {
-				println("Error unmarshalling padDelete data:", err.Error())
+				h.Logger.Warn("Error unmarshalling padDelete data:", err.Error())
 				return
 			}
 
@@ -314,7 +314,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 			}
 			c.SafeSend(responseBytes)
 		}
@@ -337,7 +337,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 				return
 			}
 			c.SafeSend(responseBytes)
@@ -353,7 +353,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 			resp[1] = totalUserMessage
 			responseBytes, err := json.Marshal(resp)
 			if err != nil {
-				println("Error marshalling response:", err.Error())
+				h.Logger.Warn("Error marshalling response:", err.Error())
 				return
 			}
 			c.SafeSend(responseBytes)
@@ -455,7 +455,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 				SessionID string `json:"sessionId"`
 			}
 			if err := json.Unmarshal(message.Data, &kickData); err != nil {
-				println("Error unmarshalling kickUser data:", err.Error())
+				h.Logger.Warn("Error unmarshalling kickUser data:", err.Error())
 				return
 			}
 			h.hub.ClientsRWMutex.RLock()
@@ -485,7 +485,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 				Limit int    `json:"limit"`
 			}
 			if err := json.Unmarshal(message.Data, &searchData); err != nil {
-				println("Error unmarshalling searchPadContent:", err.Error())
+				h.Logger.Warn("Error unmarshalling searchPadContent:", err.Error())
 				return
 			}
 			if searchData.Limit <= 0 || searchData.Limit > 50 {
@@ -571,7 +571,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 				PadNames []string `json:"padNames"`
 			}
 			if err := json.Unmarshal(message.Data, &bulkData); err != nil {
-				println("Error unmarshalling bulkDeletePads:", err.Error())
+				h.Logger.Warn("Error unmarshalling bulkDeletePads:", err.Error())
 				return
 			}
 			deleted := 0
@@ -597,7 +597,7 @@ func (h AdminMessageHandler) HandleMessage(message admin.EventMessage, retrieved
 			c.SafeSend(responseBytes)
 		}
 	default:
-		println("Unknown admin event:", message.Event)
+		h.Logger.Warn("Unknown admin event:", message.Event)
 	}
 }
 
@@ -624,14 +624,14 @@ func (h AdminMessageHandler) DeleteRevisions(padId string, keepRevisions int) er
 	h.Logger.Infof("Deleting revisions for pad %s until revision %d", padId, cleanupUntilRevision)
 	compressedChangeset, err := h.padMessageHandler.ComposePadChangesets(retrievedPad, 0, cleanupUntilRevision+1)
 	if err != nil {
-		println("Error composing changeset:", err.Error())
+		h.Logger.Warn("Error composing changeset:", err.Error())
 		return err
 	}
 
 	// Save revisions to keep (we need to resave because of changed changesets due to compression)
 	revisionsToKeep, err := retrievedPad.GetRevisions(0, retrievedPad.Head)
 	if err != nil {
-		println("Error getting revisions to keep:", err.Error())
+		h.Logger.Warn("Error getting revisions to keep:", err.Error())
 		return err
 	}
 	currentRevsToKeep := make(map[int]db2.PadSingleRevision)
@@ -640,7 +640,7 @@ func (h AdminMessageHandler) DeleteRevisions(padId string, keepRevisions int) er
 	}
 
 	if err := retrievedPad.RemoveAllSavedRevisions(); err != nil {
-		println("Error removing saved revisions:", err.Error())
+		h.Logger.Warn("Error removing saved revisions:", err.Error())
 		return err
 	}
 
@@ -667,7 +667,7 @@ func (h AdminMessageHandler) DeleteRevisions(padId string, keepRevisions int) er
 	pool := padContent.Pool
 	optNewAtext, err := changeset.ApplyToAText(compressedChangeset, newAtext, pool)
 	if err != nil {
-		println("Error applying compressed changeset to atext:", err.Error())
+		h.Logger.Warn("Error applying compressed changeset to atext:", err.Error())
 		return err
 	}
 	newAtext = *optNewAtext
@@ -675,7 +675,7 @@ func (h AdminMessageHandler) DeleteRevisions(padId string, keepRevisions int) er
 	createdRevision := adminutils.CreateRevision(compressedChangeset, currentRevsToKeep[cleanupUntilRevision].Timestamp, true, currentRevsToKeep[cleanupUntilRevision].AuthorId, newAtext, pool)
 
 	if err := h.store.SaveRevision(padContent.Id, 0, createdRevision.Changeset, newAtext.ToDBAText(), pool.ToRevDB(), createdRevision.Meta.Author, createdRevision.Meta.Timestamp); err != nil {
-		println("Error saving compressed revision:", err.Error())
+		h.Logger.Warn("Error saving compressed revision:", err.Error())
 		return err
 	}
 	for i := 0; i < keepRevisions; i++ {
@@ -684,19 +684,19 @@ func (h AdminMessageHandler) DeleteRevisions(padId string, keepRevisions int) er
 
 		currentRevisionDb, ok := currentRevsToKeep[rev]
 		if !ok {
-			println("Error: revision", rev, "not found in current revisions to keep")
+			h.Logger.Warn("Error: revision", rev, "not found in current revisions to keep")
 			return errors.New("revision not found in current revisions to keep")
 		}
 		optNewAtext, err = changeset.ApplyToAText(currentRevisionDb.Changeset, newAtext, pool)
 		if err != nil {
-			println("Error applying changeset to atext for revision", rev, ":", err.Error())
+			h.Logger.Warn("Error applying changeset to atext for revision", rev, ":", err.Error())
 			return err
 		}
 		newAtext = *optNewAtext
 
 		createdRevision = adminutils.CreateRevision(currentRevisionDb.Changeset, currentRevisionDb.Timestamp, true, currentRevisionDb.AuthorId, newAtext, pool)
 		if err := h.store.SaveRevision(padContent.Id, newRev, createdRevision.Changeset, newAtext.ToDBAText(), pool.ToRevDB(), createdRevision.Meta.Author, createdRevision.Meta.Timestamp); err != nil {
-			println("Error saving revision after deleting:", err.Error())
+			h.Logger.Warn("Error saving revision after deleting:", err.Error())
 			return err
 		}
 	}

--- a/lib/ws/PadMessageHandler.go
+++ b/lib/ws/PadMessageHandler.go
@@ -119,6 +119,14 @@ func NewPadMessageHandler(db db2.DataStore, hooks *hooks.Hook, padManager *pad.M
 	return &padMessageHandler
 }
 
+// sendDisconnectMessage tells the client to disconnect for the given reason
+// (e.g. "badChangeset"), mirroring the original's
+// socket.emit('message', {disconnect: reason}).
+func sendDisconnectMessage(client *Client, reason string) {
+	msg, _ := json.Marshal([]interface{}{"message", map[string]string{"disconnect": reason}})
+	client.SafeSend(msg)
+}
+
 func (p *PadMessageHandler) handleUserChanges(task Task) {
 	var wireApool = apool.NewAPool()
 	var newAPool = apool.NewAPool()
@@ -133,26 +141,30 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 
 	var retrievedPad, err = p.padManager.GetPad(session.PadId, nil, &session.Author)
 	if err != nil {
-		println("Error retrieving pad", err)
+		p.Logger.Warnf("Error retrieving pad %s: %v", session.PadId, err)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 	checkedRep, err := changeset.CheckRep(task.message.Data.Data.Changeset)
 
 	if err != nil {
-		println("Error checking rep", err.Error())
+		p.Logger.Warnf("Error checking rep of changeset %s: %v", task.message.Data.Data.Changeset, err)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 
 	unpackedChangeset, err := changeset.Unpack(*checkedRep)
 
 	if err != nil {
-		println("Error retrieving changeset", err)
+		p.Logger.Warnf("Error unpacking changeset %s: %v", *checkedRep, err)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 	deserializedOps, errWhenDeserializing := changeset.DeserializeOps(unpackedChangeset.Ops)
 
 	if errWhenDeserializing != nil {
-		println("error when deserializing ops")
+		p.Logger.Warnf("Error deserializing ops of changeset %s: %v", *checkedRep, errWhenDeserializing)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 
@@ -182,10 +194,12 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 				}, &dontAdd) != -1
 				if !known {
 					p.Logger.Warnf("Author %s tried to set unknown author %s on existing text", session.Author, *opAuthorId)
+					sendDisconnectMessage(task.socket, "badChangeset")
 					return
 				}
 			} else {
 				p.Logger.Warnf("Author %s tried to submit changes as author %s (op %s)", session.Author, *opAuthorId, op.OpCode)
+				sendDisconnectMessage(task.socket, "badChangeset")
 				return
 			}
 		}
@@ -199,6 +213,7 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 		if op.OpCode == "+" && (opAuthorId == nil || *opAuthorId == "") {
 			p.Logger.Warnf("Author %s submitted an insert without an author attribute in changeset %s",
 				session.Author, task.message.Data.Data.Changeset)
+			sendDisconnectMessage(task.socket, "badChangeset")
 			return
 		}
 		// Upstream #7773: defense-in-depth — reject any wire-borne `*N`
@@ -211,6 +226,7 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 		if opAuthorId != nil && *opAuthorId == pad2.SystemAuthorId {
 			p.Logger.Warnf("Author %s attempted to submit changes as the reserved system author %s in changeset %s",
 				session.Author, *opAuthorId, task.message.Data.Data.Changeset)
+			sendDisconnectMessage(task.socket, "badChangeset")
 			return
 		}
 	}
@@ -237,6 +253,7 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 		var revisionPad, err = retrievedPad.GetRevision(r)
 		if err != nil {
 			p.Logger.Warnf("Error retrieving revision %d: %v", r, err)
+			sendDisconnectMessage(task.socket, "badChangeset")
 			return
 		}
 
@@ -245,6 +262,7 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 			unpackedChangeset, err = changeset.Unpack(canonicalCs)
 			if err != nil {
 				p.Logger.Warnf("Error unpacking changeset: %v", err)
+				sendDisconnectMessage(task.socket, "badChangeset")
 				return
 			}
 			rebasedChangeset = changeset.Identity(unpackedChangeset.OldLen)
@@ -256,6 +274,7 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 		optRebasedChangeset, err := changeset.Follow(revisionPad.Changeset, rebasedChangeset, false, &retrievedPad.Pool)
 		if err != nil {
 			p.Logger.Warnf("Error rebasing changeset at rev %d: %v for %s", r, err, retrievedPad.Id)
+			sendDisconnectMessage(task.socket, "badChangeset")
 			return
 		}
 		rebasedChangeset = *optRebasedChangeset
@@ -268,12 +287,14 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 
 	if err != nil {
 		p.Logger.Warnf("Error retrieving old len from changeset: %v", err)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 
 	if *oldLen != utf8.RuneCountInString(prevText) {
 		p.Logger.Warnf("Can't apply changeset to pad text: oldLen=%d, prevTextLen=%d, baseRev=%d, headRev=%d",
 			*oldLen, utf8.RuneCountInString(prevText), r, retrievedPad.Head)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 
@@ -288,6 +309,7 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 	projectedText, projectErr := changeset.ApplyToText(rebasedChangeset, prevText)
 	if projectErr != nil {
 		p.Logger.Warnf("Error projecting changeset application: %v", projectErr)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 	if projectedText == nil || !strings.HasSuffix(*projectedText, "\n") {
@@ -296,12 +318,14 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 			projLen = utf8.RuneCountInString(*projectedText)
 		}
 		p.Logger.Warnf("Rejected USER_CHANGES whose application would leave the pad without a trailing '\\n' (length %d). Every USER_CHANGES must preserve the \"doc ends with \\n\" invariant.", projLen)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 
 	newRev, err := retrievedPad.AppendRevision(rebasedChangeset, &session.Author)
 	if err != nil {
-		println("Error appending revision", err.Error())
+		p.Logger.Errorf("Error appending revision: %v", err)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
 	// The head revision will either stay the same or increase by 1 depending on whether the
@@ -312,9 +336,21 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 
 	if !slices.Contains(rangeForRevs, *newRev) {
 		p.Logger.Warnf("Head revision after appending changeset is unexpected. Expected: %v, Got: %d", rangeForRevs, *newRev)
+		sendDisconnectMessage(task.socket, "badChangeset")
 		return
 	}
-	finalRev := retrievedPad.Head
+	finalRev := *newRev
+
+	// Mirror the original's _correctMarkersInPad: if the accepted revision
+	// left line markers (e.g. list bullets) that are not at the start of a
+	// line, append a correction revision that removes them. The correction
+	// is broadcast via UpdatePadClients below; ACCEPT_COMMIT still carries
+	// the user's own revision number.
+	if correction := p.correctMarkersInPad(retrievedPad.AText, retrievedPad.Pool); correction != nil {
+		if _, err := retrievedPad.AppendRevision(*correction, &session.Author); err != nil {
+			p.Logger.Errorf("Error appending marker-correction revision: %v", err)
+		}
+	}
 
 	// The client assumes that ACCEPT_COMMIT and NEW_CHANGES messages arrive in order. Make sure we
 	// have already sent any previous ACCEPT_COMMIT and NEW_CHANGES messages.
@@ -336,11 +372,11 @@ func (p *PadMessageHandler) handleUserChanges(task Task) {
 		optTime, err := retrievedPad.GetRevisionDate(finalRev)
 		if err != nil {
 			p.Logger.Warnf("Error retrieving revision date: %v", err)
+			sendDisconnectMessage(task.socket, "badChangeset")
 			return
 		}
 		session.Time = *optTime
 	}
-	retrievedPad.Head = finalRev
 	p.UpdatePadClients(retrievedPad)
 }
 
@@ -366,7 +402,7 @@ func (p *PadMessageHandler) ComposePadChangesets(retrievedPad *pad2.Pad, startNu
 		cs := (*requiredChangesets)[r]
 		optStartChangeset, err := changeset.Compose(startChangeset, cs.Changeset, &padPool)
 		if err != nil {
-			println("Error composing changesets", err)
+			p.Logger.Warn("Error composing changesets", err)
 			return "", err
 		}
 		startChangeset = *optStartChangeset
@@ -441,7 +477,7 @@ func (p *PadMessageHandler) HandleMessage(message any, client *Client, retrieved
 		} else {
 			ip = client.ClientIP
 		}
-		println("pre-CLIENT_READY message from IP " + ip)
+		p.Logger.Warn("pre-CLIENT_READY message from IP " + ip)
 		return
 	}
 
@@ -493,7 +529,7 @@ func (p *PadMessageHandler) HandleMessage(message any, client *Client, retrieved
 	var readonly = thisSession.ReadOnly
 	var thisSessionNewRetrieved = p.SessionStore.getSession(client.SessionId)
 	if thisSessionNewRetrieved == nil {
-		println("Client disconnected")
+		p.Logger.Warn("Client disconnected")
 		return
 	}
 
@@ -518,7 +554,7 @@ func (p *PadMessageHandler) HandleMessage(message any, client *Client, retrieved
 	case ws.UserChange:
 		{
 			if readonly {
-				println("write attempt on read-only pad")
+				p.Logger.Warn("write attempt on read-only pad")
 				return
 			}
 
@@ -541,32 +577,36 @@ func (p *PadMessageHandler) HandleMessage(message any, client *Client, retrieved
 			}
 			p.HandleSavedRevisionMessage(foundPad, sess.Author)
 		}
+	case ws.ClientMessage:
+		{
+			p.HandleClientMessage(expectedType, client, thisSession)
+		}
 	case ws.GetChatMessages:
 		{
 			if expectedType.Data.Data.Start < 0 {
-				println("Invalid start for chat messages")
+				p.Logger.Warn("Invalid start for chat messages")
 				return
 			}
 
 			if expectedType.Data.Data.End < 0 {
-				println("Invalid end for chat messages")
+				p.Logger.Warn("Invalid end for chat messages")
 				return
 			}
 
 			var count = expectedType.Data.Data.End - expectedType.Data.Data.Start
 			if count < 0 || count > 100 {
-				println("End must be greater than start for chat messages and no more than 100 messages can be requested at once")
+				p.Logger.Warn("End must be greater than start for chat messages and no more than 100 messages can be requested at once")
 				return
 			}
 
 			retrievedPad, err := p.padManager.GetPad(thisSession.PadId, nil, &thisSession.Author)
 			if err != nil {
-				println("Error retrieving pad for chat messages", err)
+				p.Logger.Warn("Error retrieving pad for chat messages", err)
 				return
 			}
 			chatMessages, err := retrievedPad.GetChatMessages(expectedType.Data.Data.Start, expectedType.Data.Data.End)
 			if err != nil {
-				println("Error retrieving chat messages", err)
+				p.Logger.Warn("Error retrieving chat messages", err)
 				return
 			}
 
@@ -581,11 +621,6 @@ func (p *PadMessageHandler) HandleMessage(message any, client *Client, retrieved
 				if msg.DisplayName != nil && *msg.DisplayName != "" {
 					convertedMessages[len(convertedMessages)-1].UserName = msg.DisplayName
 				}
-			}
-
-			if err != nil {
-				println("Error retrieving chat messages", err)
-				return
 			}
 
 			var arr = make([]interface{}, 2)
@@ -609,22 +644,22 @@ func (p *PadMessageHandler) HandleMessage(message any, client *Client, retrieved
 			p.HandlePadDelete(client, expectedType)
 		}
 	default:
-		println("Unknown message type received")
+		p.Logger.Warn("Unknown message type received")
 	}
 }
 
 func (p *PadMessageHandler) HandleChangesetRequest(socket *Client, message ws.ChangesetReq) {
 	if (message.Data.Data.Granularity <= 0) || (message.Data.Data.Start < 0) {
-		println("Invalid changeset request parameters")
+		p.Logger.Warn("Invalid changeset request parameters")
 		return
 	}
 	start, err := utils.CheckValidRev(strconv.Itoa(message.Data.Data.Start))
 	if err != nil {
-		println("Error checking valid rev for changeset request", err)
+		p.Logger.Warn("Error checking valid rev for changeset request", err)
 		return
 	}
 	if message.Data.Data.RequestID == -1 {
-		println("Invalid request ID for changeset request")
+		p.Logger.Warn("Invalid request ID for changeset request")
 		return
 	}
 
@@ -633,13 +668,13 @@ func (p *PadMessageHandler) HandleChangesetRequest(socket *Client, message ws.Ch
 	end := startRev + (message.Data.Data.Granularity * 100)
 	session := p.SessionStore.getSession(socket.SessionId)
 	if session == nil {
-		println("Session not found for changeset request")
+		p.Logger.Warn("Session not found for changeset request")
 		return
 	}
 
 	retrievedPad, err := p.padManager.GetPad(session.PadId, nil, &session.Author)
 	if err != nil {
-		println("Error retrieving pad for changeset request", err)
+		p.Logger.Warn("Error retrieving pad for changeset request", err)
 		return
 	}
 	headRev := retrievedPad.Head
@@ -649,7 +684,7 @@ func (p *PadMessageHandler) HandleChangesetRequest(socket *Client, message ws.Ch
 
 	data, err := p.getChangesetInfo(*retrievedPad, startRev, end, message.Data.Data.Granularity)
 	if err != nil {
-		println("Error getting changeset info for changeset request", err)
+		p.Logger.Warn("Error getting changeset info for changeset request", err)
 		return
 	}
 
@@ -665,7 +700,7 @@ func (p *PadMessageHandler) HandleChangesetRequest(socket *Client, message ws.Ch
 	arr[1] = messageToSend
 	encoded, err := json.Marshal(arr)
 	if err != nil {
-		println("Error marshalling changeset response", err)
+		p.Logger.Warn("Error marshalling changeset response", err)
 		return
 	}
 
@@ -775,14 +810,14 @@ func (p *PadMessageHandler) getChangesetInfo(retrievedPad pad2.Pad, startNum int
 
 	lines, err := getPadLines(&retrievedPad, startNum-1)
 	if err != nil {
-		println("Error getting pad lines", err)
+		p.Logger.Warn("Error getting pad lines", err)
 		return nil, err
 	}
 
 	for _, composeNeeded := range compositesChangesetNeeded {
 		changesetComposed, err := p.composePadChangesets(&retrievedPad, composeNeeded.Start, composeNeeded.End)
 		if err != nil {
-			println("Error composing pad changesets", err)
+			p.Logger.Warn("Error composing pad changesets", err)
 			return nil, err
 		}
 		composedChangesets[fmt.Sprintf("%d/%d", composeNeeded.Start, composeNeeded.End)] = changesetComposed
@@ -806,15 +841,15 @@ func (p *PadMessageHandler) getChangesetInfo(retrievedPad pad2.Pad, startNum int
 		forwards := composedChangesets[fmt.Sprintf("%d/%d", compositeStart, compositeEnd)]
 		backwards, err := changeset.Inverse(forwards, lines.TextLines, lines.Alines, &retrievedPad.Pool)
 		if err != nil {
-			println("Error getting inverse changeset", err)
+			p.Logger.Warn("Error getting inverse changeset", err)
 			return nil, err
 		}
 		if err := changeset.MutateAttributionLines(forwards, &lines.Alines, &retrievedPad.Pool); err != nil {
-			println("Error mutating attribution lines", err)
+			p.Logger.Warn("Error mutating attribution lines", err)
 			return nil, err
 		}
 		if err := changeset.MutateTextLines(forwards, &lines.TextLines); err != nil {
-			println("Error mutating text lines", err)
+			p.Logger.Warn("Error mutating text lines", err)
 			return nil, err
 		}
 
@@ -850,19 +885,19 @@ func (p *PadMessageHandler) getChangesetInfo(retrievedPad pad2.Pad, startNum int
 func (p *PadMessageHandler) SendChatMessageToPadClients(session *ws.Session, chatMessage ws.ChatMessageData) {
 	var retrievedPad, err = p.padManager.GetPad(session.PadId, nil, chatMessage.AuthorId)
 	if err != nil {
-		println("Error retrieving pad for chat message", err)
+		p.Logger.Warn("Error retrieving pad for chat message", err)
 		return
 	}
 	// pad.appendChatMessage() ignores the displayName property so we don't need to wait for
 	// authorManager.getAuthorName() to resolve before saving the message to the database.
 	_, err = retrievedPad.AppendChatMessage(chatMessage.AuthorId, *chatMessage.Time, chatMessage.Text)
 	if err != nil {
-		println("Error appending chat message to pad", err)
+		p.Logger.Warn("Error appending chat message to pad", err)
 		return
 	}
 	authorName, err := p.authorManager.GetAuthorName(*chatMessage.AuthorId)
 	if err != nil {
-		println("Error retrieving author name for chat message", err)
+		p.Logger.Warn("Error retrieving author name for chat message", err)
 	}
 	if authorName != nil && *authorName != "" {
 		chatMessage.DisplayName = authorName
@@ -912,7 +947,7 @@ func (p *PadMessageHandler) HandlePadDelete(client *Client, padDeleteMessage Pad
 	var session = p.SessionStore.getSession(client.SessionId)
 
 	if session == nil || session.Author == "" || session.PadId == "" {
-		println("Session not ready")
+		p.Logger.Warn("Session not ready")
 		return
 	}
 
@@ -921,29 +956,29 @@ func (p *PadMessageHandler) HandlePadDelete(client *Client, padDeleteMessage Pad
 		return
 	}
 	if !*retrievedPad {
-		println("Pad does not exist")
+		p.Logger.Warn("Pad does not exist")
 		return
 	}
 	retrievedPadObj, err := p.padManager.GetPad(padDeleteMessage.Data.PadID, nil, nil)
 	if err != nil {
-		println("Error retrieving pad")
+		p.Logger.Warn("Error retrieving pad")
 		return
 	}
 	// Only the one doing the first revision can delete the pad, otherwise people could troll a lot
 	firstContributor, err := retrievedPadObj.GetRevisionAuthor(0)
 	if err != nil {
-		println("Error retrieving first contributor")
+		p.Logger.Warn("Error retrieving first contributor")
 		return
 	}
 
 	if *firstContributor != session.Author {
-		println("Only first contributor can delete the pad")
+		p.Logger.Warn("Only first contributor can delete the pad")
 		return
 	}
 
 	err = p.DeletePad(retrievedPadObj.Id)
 	if err != nil {
-		println("Error deleting pad", err)
+		p.Logger.Warn("Error deleting pad", err)
 		return
 	}
 }
@@ -988,13 +1023,13 @@ func (p *PadMessageHandler) HandleUserInfoUpdate(userInfo UserInfoUpdate, client
 	var session = p.SessionStore.getSession(client.SessionId)
 
 	if session == nil || session.Author == "" || session.PadId == "" {
-		println("Session not ready")
+		p.Logger.Warn("Session not ready")
 		return
 	}
 
 	var match, _ = regexp.MatchString("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", *userInfo.Data.UserInfo.ColorId)
 	if !match {
-		println("Malformed color", *userInfo.Data.UserInfo.ColorId)
+		p.Logger.Warn("Malformed color", *userInfo.Data.UserInfo.ColorId)
 		return
 	}
 
@@ -1037,14 +1072,18 @@ func (p *PadMessageHandler) HandleUserInfoUpdate(userInfo UserInfoUpdate, client
 }
 
 func (p *PadMessageHandler) correctMarkersInPad(atext apool.AText, apool apool.APool) *string {
-	var text = atext.Text
+	var text = []rune(atext.Text)
 
 	// collect char positions of line markers (e.g. bullets) in new atext
 	// that aren't at the start of a line
 	var badMarkers = make([]int, 0)
 	var offset = 0
 
-	deserializedOps, _ := changeset.DeserializeOps(atext.Attribs)
+	deserializedOps, err := changeset.DeserializeOps(atext.Attribs)
+	if err != nil {
+		p.Logger.Warnf("Error deserializing atext attribs while correcting markers: %v", err)
+		return nil
+	}
 
 	for _, op := range *deserializedOps {
 		var attribs = changeset.FromString(op.Attribs, &apool)
@@ -1069,10 +1108,10 @@ func (p *PadMessageHandler) correctMarkersInPad(atext apool.AText, apool apool.A
 	// create changeset that removes these bad markers
 	offset = 0
 
-	var builder = changeset.NewBuilder(utf8.RuneCountInString(text))
+	var builder = changeset.NewBuilder(len(text))
 
 	for _, i := range badMarkers {
-		builder.KeepText(text[offset:i], nil, nil)
+		builder.KeepText(string(text[offset:i]), nil, nil)
 		builder.Remove(1, 0)
 		offset = i + 1
 	}
@@ -1097,7 +1136,7 @@ func (p *PadMessageHandler) HandleDisconnectOfPadClient(client *Client, settings
 	var roomSockets = p.GetRoomSockets(thisSession.PadId)
 	var authorToRemove, err = p.authorManager.GetAuthor(thisSession.Author)
 	if err != nil {
-		println("Error retrieving author for disconnect")
+		p.Logger.Warn("Error retrieving author for disconnect")
 		return
 	}
 
@@ -1144,7 +1183,7 @@ func (p *PadMessageHandler) HandleDisconnectOfPadClient(client *Client, settings
 
 func (p *PadMessageHandler) HandleClientReadyMessage(ready ws.ClientReady, client *Client, thisSession *ws.Session, retrievedSettings *settings.Settings, logger *zap.SugaredLogger) {
 	if ready.Data.UserInfo.ColorId != nil && !colorRegEx.MatchString(*ready.Data.UserInfo.ColorId) {
-		println("Invalid color id")
+		p.Logger.Warn("Invalid color id")
 		ready.Data.UserInfo.ColorId = nil
 	}
 
@@ -1159,7 +1198,7 @@ func (p *PadMessageHandler) HandleClientReadyMessage(ready ws.ClientReady, clien
 	var retrievedPad, err = p.padManager.GetPad(thisSession.PadId, nil, &thisSession.Author)
 
 	if err != nil {
-		println("Error getting pad")
+		p.Logger.Warn("Error getting pad")
 		return
 	}
 
@@ -1183,12 +1222,12 @@ func (p *PadMessageHandler) HandleClientReadyMessage(ready ws.ClientReady, clien
 	var foundAuthor, errAuth = p.authorManager.GetAuthor(thisSession.Author)
 
 	if errAuth != nil {
-		println("Error retrieving author")
+		p.Logger.Warn("Error retrieving author")
 		return
 	}
 
 	if foundAuthor == nil || (*foundAuthor).Id == "" {
-		println("Author not found")
+		p.Logger.Warn("Author not found")
 		return
 	}
 
@@ -1363,7 +1402,7 @@ func (p *PadMessageHandler) HandleClientReadyMessage(ready ws.ClientReady, clien
 
 		retrivedClientVars, err := p.factory.NewClientVars(*retrievedPad, thisSession, wirePool, atextSnapshot.Attribs, historicalAuthorData, retrievedSettings, numConnected)
 		if err != nil {
-			println("Error creating client vars", err.Error())
+			p.Logger.Warn("Error creating client vars", err.Error())
 			return
 		}
 		// Honor the atomic snapshot in the outgoing CLIENT_VARS.
@@ -1399,7 +1438,7 @@ func (p *PadMessageHandler) HandleClientReadyMessage(ready ws.ClientReady, clien
 
 	retrievedAuthor, err := p.authorManager.GetAuthor(thisSession.Author)
 	if err != nil {
-		println("Error retrieving author for USER_NEWINFO broadcast")
+		p.Logger.Warn("Error retrieving author for USER_NEWINFO broadcast")
 		return
 	}
 
@@ -1440,7 +1479,7 @@ func (p *PadMessageHandler) HandleClientReadyMessage(ready ws.ClientReady, clien
 		}
 		otherAuthor, err := p.authorManager.GetAuthor(sinfo.Author)
 		if err != nil {
-			println("Error retrieving author for USER_NEWINFO send to new client")
+			p.Logger.Warn("Error retrieving author for USER_NEWINFO send to new client")
 			continue
 		}
 		var userNewInfoDat = ws.UserNewInfoDat{
@@ -1492,7 +1531,7 @@ func (p *PadMessageHandler) UpdatePadClients(pad *pad2.Pad) {
 		}
 
 		for sessionInfo.Revision < pad.Head {
-			println("Sending NEW_CHANGES to client for pad", pad.Id, "from rev", sessionInfo.Revision, "to", pad.Head)
+			p.Logger.Warn("Sending NEW_CHANGES to client for pad", pad.Id, "from rev", sessionInfo.Revision, "to", pad.Head)
 			var r = sessionInfo.Revision + 1
 			if _, ok := revCache[r]; !ok {
 				revCache[r], _ = pad.GetRevision(r)
@@ -1524,7 +1563,7 @@ func (p *PadMessageHandler) UpdatePadClients(pad *pad2.Pad) {
 			marshalledMessage, err := json.Marshal(arr)
 
 			if err != nil {
-				println("Error sending NEW_CHANGES message to client")
+				p.Logger.Warn("Error sending NEW_CHANGES message to client")
 				return
 			}
 
@@ -1532,6 +1571,44 @@ func (p *PadMessageHandler) UpdatePadClients(pad *pad2.Pad) {
 			sessionInfo.Time = currentTime
 			sessionInfo.Revision = r
 		}
+	}
+}
+
+// HandleClientMessage handles the COLLABROOM CLIENT_MESSAGE family,
+// mirroring the original's handleSuggestUserName / handlePadOptionsMessage.
+func (p *PadMessageHandler) HandleClientMessage(message ws.ClientMessage, client *Client, session *ws.Session) {
+	if session == nil || session.PadId == "" || session.Author == "" {
+		p.Logger.Warn("CLIENT_MESSAGE received before session was ready")
+		return
+	}
+
+	payload := message.Data.Data.Payload
+	switch payload.Type {
+	case "suggestUserName":
+		if payload.NewName == "" || payload.UnnamedId == "" {
+			p.Logger.Warnf("suggestUserName from %s is missing newName or unnamedId", session.Author)
+			return
+		}
+		// Relay the message verbatim to the sockets of the unnamed author.
+		arr := []any{"message", message.Data}
+		encoded, err := json.Marshal(arr)
+		if err != nil {
+			p.Logger.Errorf("Error marshalling suggestUserName relay: %v", err)
+			return
+		}
+		for _, socket := range p.GetRoomSockets(session.PadId) {
+			targetSession := p.SessionStore.getSession(socket.SessionId)
+			if targetSession != nil && targetSession.Author == payload.UnnamedId {
+				socket.SafeSend(encoded)
+			}
+		}
+	case "padoptions":
+		// The original gates pad-wide settings behind enablePadWideSettings
+		// (default off) and per-pad settings storage, neither of which this
+		// implementation supports yet — ignore, like the original default.
+		p.Logger.Debugf("Ignoring padoptions CLIENT_MESSAGE from %s: pad-wide settings are not supported", session.Author)
+	default:
+		p.Logger.Warnf("Unknown CLIENT_MESSAGE payload type %q from %s", payload.Type, session.Author)
 	}
 }
 

--- a/lib/ws/client.go
+++ b/lib/ws/client.go
@@ -131,7 +131,7 @@ func (c *Client) readPump(retrievedSettings *settings.Settings, logger *zap.Suga
 		}
 		retrievedSettings.CommitRateLimiting.LoadTest = retrievedSettings.LoadTest
 		if err := ratelimiter.CheckRateLimit(ratelimiter.IPAddress(c.ClientIP), retrievedSettings.CommitRateLimiting); err != nil {
-			println("Rate limit exceeded:", err.Error())
+			logger.Warn("Rate limit exceeded:", err.Error())
 			continue
 		}
 		message = bytes.TrimSpace(bytes.Replace(message, newline, space, -1))
@@ -141,7 +141,7 @@ func (c *Client) readPump(retrievedSettings *settings.Settings, logger *zap.Suga
 			var clientReady ws.ClientReady
 			err := json.Unmarshal(message, &clientReady)
 			if err != nil {
-				println("Error unmarshalling", err)
+				logger.Warn("Error unmarshalling", err)
 			}
 
 			c.Handler.HandleMessage(clientReady, c, retrievedSettings, logger)
@@ -211,6 +211,15 @@ func (c *Client) readPump(retrievedSettings *settings.Settings, logger *zap.Suga
 				continue
 			}
 			c.Handler.HandleMessage(chatMessage, c, retrievedSettings, logger)
+		} else if strings.Contains(decodedMessage, "CLIENT_MESSAGE") {
+			var clientMessage ws.ClientMessage
+			err := json.Unmarshal(message, &clientMessage)
+
+			if err != nil {
+				logger.Error("Error unmarshalling CLIENT_MESSAGE: ", err)
+				continue
+			}
+			c.Handler.HandleMessage(clientMessage, c, retrievedSettings, logger)
 		}
 
 		c.Hub.Broadcast <- message

--- a/lib/ws/globals.go
+++ b/lib/ws/globals.go
@@ -3,6 +3,8 @@ package ws
 import (
 	"sync"
 
+	"github.com/ether/etherpad-go/lib/apool"
+
 	"github.com/ether/etherpad-go/lib/models/ws"
 )
 
@@ -204,4 +206,9 @@ func (s *SessionStore) GetSessionForTest(sessionId string) *ws.Session {
 // RemoveSessionForTest removes a session for testing
 func (s *SessionStore) RemoveSessionForTest(sessionId string) {
 	s.removeSession(sessionId)
+}
+
+// CorrectMarkersInPadForTest exposes correctMarkersInPad for tests.
+func (p *PadMessageHandler) CorrectMarkersInPadForTest(atext apool.AText, pool apool.APool) *string {
+	return p.correctMarkersInPad(atext, pool)
 }


### PR DESCRIPTION
## Summary

Systematic comparison of this Go implementation against the original etherpad-lite surfaced a set of protocol/API gaps and several real bugs. This PR closes them:

### WebSocket protocol parity
- **`disconnect: badChangeset`** is now sent on every `USER_CHANGES` rejection path — previously the server only logged and the client waited forever for `ACCEPT_COMMIT` (stuck sync state, lost edits).
- **`correctMarkersInPad` was dead code** — it is now called after each accepted revision like the original `_correctMarkersInPad`, appending a correction revision when list markers end up off line-start (plus a byte-vs-rune indexing fix in the scan).
- **`CLIENT_MESSAGE` family**: `suggestUserName` is relayed to the target author's sockets; `padoptions` is ignored, matching the original's default (`enablePadWideSettings` off).
- All `println` calls in `lib/ws` replaced with the structured zap logger.

### Sessions
- **`SessionDatabase` was a no-op stub** — implemented on top of the existing `sessionstorage` table and wired into the fiber session store: cookie sessions now survive restarts. Also fixed all three SQL backends hardcoding an empty string into the `connections` column.
- **New API session endpoints**: `POST/GET/DELETE /admin/api/sessions[...]`, `GET /admin/api/groups/:id/sessions`, `GET /admin/api/authors/:id/sessions`.

### HTTP API
- Wired up the prepared-but-unreachable pad operations: **copyPad, copyPadWithoutHistory, movePad, get/setPublicStatus** (request types existed in `operations.go`, but no handlers/routes).
- Groups: **createGroupIfNotExistsFor** (deterministic group id from the mapper), **listAllGroups** (new `GetGroups` on all four backends), **listPads** of a group.

### Pre-existing bugs found by the new tests
- **Group pads were entirely unusable**: the pad id regex was missing `\$` in the group branch (original: `g\.[a-zA-Z0-9]{16}\$`), so every `g.xxx$name` id failed validation. An existing test even skirted this as a "known limitation".
- **System-author revisions violated the `padRev → globalAuthor` FK** on SQL backends (`a.etherpad-system` was never created); the row is now ensured on first use.
- **Changeset library panics**: `Follow`/`Inverse`/`Compose` panicked on malformed input that slips past `CheckRep` (DoS risk) — converted to error returns with regression tests.
- **Flaky `bulkDeletePads` test on MySQL**: the mock write pump gave up after 500 ms of handler silence; it now drains deterministically (and the WS suite got faster).

## Test plan
- `go test -p 1 ./...` — all 27 packages green (Memory/SQLite/Postgres/MySQL via testcontainers)
- New tests: badChangeset disconnect, marker correction, SessionDatabase persistence/expiry (11 tests), pad copy/move/publicStatus, session API CRUD + listings, groups createIfNotExistsFor/listAllGroups/listPads, CLIENT_MESSAGE relay, changeset malformed-input regressions
- `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
