### PR TITLE
chore(dependabot): add release-age cooldown to npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,12 @@ updates:
       interval: "daily"
     versioning-strategy: "increase"
     open-pull-requests-limit: 30
+    # Wait until a release has aged before opening a PR. CI installs the
+    # latest pnpm, which enforces a 24h minimumReleaseAge supply-chain gate on
+    # the lockfile; opening PRs sooner just produces runs that fail that gate.
+    # The cooldown keeps the protection and avoids the doomed PRs.
+    cooldown:
+      default-days: 3
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -39,6 +45,10 @@ updates:
       interval: "daily"
     versioning-strategy: "increase"
     open-pull-requests-limit: 30
+    # See the /ui config above: cooldown clears pnpm's 24h minimumReleaseAge
+    # supply-chain gate so Dependabot doesn't open PRs that are sure to fail CI.
+    cooldown:
+      default-days: 3
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Why

CI installs the **latest** pnpm (`build.yml`: `npm install -g pnpm@latest`), which is newer than the repo's pinned `pnpm@11.5.2` and enforces a default **24h `minimumReleaseAge`** supply-chain gate on the lockfile. Dependabot opens npm bumps the same day a version is published, so those PRs fail CI with:

```
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
  lucide-react@1.18.0 was published at ..., within the minimumReleaseAge cutoff
```

(seen on #283 — `lucide-react` 1.17.0 → 1.18.0).

## What

Add a **3-day `cooldown`** to the `/ui` and `/admin` npm update configs so Dependabot waits until a release has aged past the gate before opening a PR. This:

- **Keeps** the supply-chain protection (the 24h gate stays on).
- **Stops** the doomed-from-the-start PRs that can never pass CI on publish day.

Only the npm ecosystems feed `pnpm-lock.yaml`, so the gate doesn't affect the github-actions/docker/gomod configs — they're left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
