### PR TITLE
fix(ui): keep settings dropdown items inside <ep-dropdown> (font/language menus)

### DIFF
--- a/assets/pad/pad.templ
+++ b/assets/pad/pad.templ
@@ -122,7 +122,7 @@ templ SettingsPopup(translations map[string]string, availablefonts []string, set
               </p>
 
               <div class="dropdowns-container">
-                <p class="dropdown-line">
+                <div class="dropdown-line">
                   <label>{translations["pad.settings.fontType"]}</label>
                   <ep-dropdown id="viewfontmenu" align="left" trigger="click">
                     <button slot="trigger" type="button" class="dropdown-select-trigger">{translations["pad.settings.fontType.normal"]}</button>
@@ -133,9 +133,9 @@ templ SettingsPopup(translations map[string]string, availablefonts []string, set
                       }
                     </div>
                   </ep-dropdown>
-                </p>
+                </div>
 
-                <p class="dropdown-line">
+                <div class="dropdown-line">
                   <label>{translations["pad.settings.language"]}</label>
                   <ep-dropdown id="languagemenu" align="left" trigger="click">
                     <button slot="trigger" type="button" class="dropdown-select-trigger">{translations["pad.settings.language"]}</button>
@@ -145,7 +145,7 @@ templ SettingsPopup(translations map[string]string, availablefonts []string, set
                       }
                     </div>
                   </ep-dropdown>
-                </p>
+                </div>
               </div>
               <button id="delete-pad">{translations["pad.settings.deletePad"]}</button>
               <div id="theme-switcher" style="display: none;">

--- a/assets/pad/pad_templ.go
+++ b/assets/pad/pad_templ.go
@@ -1591,7 +1591,7 @@ func SettingsPopup(translations map[string]string, availablefonts []string, sett
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, "\"></ep-checkbox></p><div class=\"dropdowns-container\"><p class=\"dropdown-line\"><label>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, "\"></ep-checkbox></p><div class=\"dropdowns-container\"><div class=\"dropdown-line\"><label>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1666,7 +1666,7 @@ func SettingsPopup(translations map[string]string, availablefonts []string, sett
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 127, "</div></ep-dropdown></p><p class=\"dropdown-line\"><label>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 127, "</div></ep-dropdown></div><div class=\"dropdown-line\"><label>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1728,7 +1728,7 @@ func SettingsPopup(translations map[string]string, availablefonts []string, sett
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 133, "</div></ep-dropdown></p></div><button id=\"delete-pad\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 133, "</div></ep-dropdown></div></div><button id=\"delete-pad\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Problem

After the WebComponents migration, the **font** and **language** settings dropdowns rendered empty — selecting a font/language did nothing, and the `font_type` / `language` playwright specs failed (`selectEpDropdownItem` timed out waiting for `<ep-dropdown-item>` to exist).

## Root cause

Both dropdowns were wrapped in `<p class="dropdown-line">`:

```html
<p class="dropdown-line">
  <label>…</label>
  <ep-dropdown id="viewfontmenu">
    <button slot="trigger">…</button>
    <div slot="content"> … <ep-dropdown-item>… </div>   <!-- block <div> -->
  </ep-dropdown>
</p>
```

The HTML parser auto-closes an open `<p>` when it hits a block-level `<div>` start tag (the `<p>` "in button scope" rule). So the `<div slot="content">` — and every `<ep-dropdown-item>` inside it — was **ejected out of the `<ep-dropdown>`** and re-parented into the settings container. The server HTML was correct; the browser DOM was not (verified: the items existed in the document but `#viewfontmenu` contained only its trigger button).

## Fix

Wrap each dropdown line in a `<div class="dropdown-line">` instead of `<p>`. `.dropdown-line` is styled by class (`margin-top: 15px`), so there's no visual regression.

## Verification

Ran the affected specs locally against a fresh build (chromium):

```
specs/font_type.spec.ts  + specs/language.spec.ts  →  8 passed
```

Confirmed the live DOM now has `#viewfontmenu` with its 8 font items (including `RobotoMono`) and `#languagemenu` populated.

> Note: other playwright specs that were red in CI (bold, alphabet, urls_become_clickable, …) pass locally and appear flaky; the remaining genuine failures (indent/outdent in `indentation` / `unordered_list`) are a separate issue tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
