### PR TITLE
fix(ui): keep editor focus on toolbar button press (fixes firefox indent)

### DIFF
--- a/ui/src/js/pad_editbar.ts
+++ b/ui/src/js/pad_editbar.ts
@@ -83,8 +83,15 @@ class ToolbarItem {
 
   bind(callback) {
     if (this.isButton()) {
+      // Preventing the default mousedown stops the button from stealing focus
+      // from the editor, so its caret/selection survives the click. Commands
+      // like indent then apply at the user's caret and typing continues to
+      // work immediately. Without this the editor is blurred and the caret has
+      // to be restored on the next focus — which firefox does asynchronously,
+      // so typing right after (e.g. indent → type) lands in the wrong place and
+      // the list indent breaks.
+      this.el.addEventListener('mousedown', (event) => event.preventDefault());
       this.el.addEventListener('click', (event) => {
-        if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
         callback(this.getCommand(), this);
         event.preventDefault();
       });


### PR DESCRIPTION
## Problem

The firefox playwright jobs failed on `indentation` / `unordered_list` (e.g. "keeps the indent on enter" → `ul li` count 1 instead of 3). chromium hit the same class of failure on `indentation:172` and `unordered_list:32/106`.

## Root cause

Toolbar buttons (`pad_editbar.ts` `ToolbarItem.bind`) called `document.activeElement.blur()` on click and **never prevented the mousedown focus-steal**. So pressing a button (e.g. **indent**) moved focus off the editor and **dropped its caret**:

- **chromium** restores the caret synchronously on the next `focus()`, so it usually still worked.
- **firefox** restores it **asynchronously**, so typing immediately after `indent` (the test does `indent → focus → type`) **raced the restore** and landed in the wrong place — the list never continued.

I reproduced it locally on firefox and confirmed with a timing probe: `0ms` after focus → broken (1 item); `500ms` → correct (3 items).

## Fix

`preventDefault` on the button's **mousedown** so the editor never loses focus (and drop the `activeElement.blur()` that destroyed it). The caret survives the click, commands apply at the user's caret, and typing works immediately on every browser.

## Verification (local)

- **firefox**: `indentation` + `unordered_list` → **12/12 passed**
- **chromium**: `indentation`, `bold`, `font_type`, `settings`, `unordered_list` → **20/20 passed** (incl. the previously-failing `indentation:172`, `unordered_list:32/106`)

No package change required — this is a pure `etherpad-go` UI fix.

> The remaining `undo` flake (ubuntu-timing undo-coalescing in the editor package) is separate and tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
