### PR TITLE
chore(deps): @samtv12345/etherpad-webcomponents 0.0.13 (undo fix, public npm)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "etherpad-webcomponents": "^0.0.11"
+    "@samtv12345/etherpad-webcomponents": "^0.0.13"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  etherpad-webcomponents: 0.0.11
+  '@samtv12345/etherpad-webcomponents': 0.0.13
 
 importers:
 
   .:
     dependencies:
-      etherpad-webcomponents:
-        specifier: 0.0.11
-        version: 0.0.11
+      '@samtv12345/etherpad-webcomponents':
+        specifier: 0.0.13
+        version: 0.0.13
     devDependencies:
       typescript:
         specifier: ^5.6.3
@@ -112,15 +112,15 @@ importers:
         specifier: ^29.0.3
         version: 29.0.3(rollup@4.59.0)
     devDependencies:
+      '@samtv12345/etherpad-webcomponents':
+        specifier: 0.0.13
+        version: 0.0.13
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
       esbuild:
         specifier: 0.28.0
         version: 0.28.0
-      etherpad-webcomponents:
-        specifier: 0.0.11
-        version: 0.0.11
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -585,6 +585,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@samtv12345/etherpad-webcomponents@0.0.13':
+    resolution: {integrity: sha512-jopdeaPKtm8e6ugj3cpypqjm9llTMz1Lut2Dx6ptwy2VaKfgTp65aUWFGsOKlkJGhVbAfa5k2T7VymdPHQbZMg==}
+
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -774,9 +777,6 @@ packages:
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-
-  etherpad-webcomponents@0.0.11:
-    resolution: {integrity: sha512-4QrJuCAXHIAm7hxffAv4cIPaXesLLSd1rfJhpOvI8gaOCvjhMSJb9wDLItwjfCMnbTHkRPQTVdAZGwwqVkyM0Q==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1341,6 +1341,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@samtv12345/etherpad-webcomponents@0.0.13':
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit: 3.3.2
+      lit-element: 4.2.2
+      lit-html: 3.3.2
+
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1512,13 +1519,6 @@ snapshots:
   escalade@3.2.0: {}
 
   estree-walker@2.0.2: {}
-
-  etherpad-webcomponents@0.0.11:
-    dependencies:
-      '@lit/reactive-element': 2.1.2
-      lit: 3.3.2
-      lit-element: 4.2.2
-      lit-html: 3.3.2
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,7 @@ allowBuilds:
   esbuild: true
 
 overrides:
-  etherpad-webcomponents: 0.0.11
+  "@samtv12345/etherpad-webcomponents": 0.0.13
+
+minimumReleaseAgeExclude:
+  - "@samtv12345/etherpad-webcomponents@0.0.13"

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "etherpad-webcomponents": "^0.0.11",
+    "@samtv12345/etherpad-webcomponents": "^0.0.13",
     "@types/node": "^25.9.2",
     "esbuild": "0.28.0",
     "typescript": "^6.0.3",

--- a/ui/src/js/ace.ts
+++ b/ui/src/js/ace.ts
@@ -23,7 +23,7 @@
  * limitations under the License.
  */
 
-import {AceEditor} from 'etherpad-webcomponents';
+import {AceEditor} from '@samtv12345/etherpad-webcomponents';
 import {editorBus} from './core/EventBus';
 import * as pluginUtils from './pluginfw/shared';
 

--- a/ui/src/js/chat.ts
+++ b/ui/src/js/chat.ts
@@ -4,7 +4,7 @@ import notifications from './notifications';
 import {editorBus} from './core/EventBus';
 import {padeditor} from './pad_editor';
 import {paduserlist} from './pad_userlist';
-import 'etherpad-webcomponents/EpChatMessage.js';
+import '@samtv12345/etherpad-webcomponents/EpChatMessage.js';
 
 // ---------------------------------------------------------------------------
 // Inline helpers (replaces padutils + padcookie dependencies)

--- a/ui/src/js/components/index.ts
+++ b/ui/src/js/components/index.ts
@@ -6,19 +6,19 @@
  * EpPluginToolbar is local-only (not in the npm package).
  */
 
-import 'etherpad-webcomponents/EpNotification.js';
-import 'etherpad-webcomponents/EpModal.js';
-import 'etherpad-webcomponents/EpToast.js';
-import 'etherpad-webcomponents/EpColorPicker.js';
-import 'etherpad-webcomponents/EpDropdown.js';
-import 'etherpad-webcomponents/EpToolbarSelect.js';
-import 'etherpad-webcomponents/EpCheckbox.js';
+import '@samtv12345/etherpad-webcomponents/EpNotification.js';
+import '@samtv12345/etherpad-webcomponents/EpModal.js';
+import '@samtv12345/etherpad-webcomponents/EpToast.js';
+import '@samtv12345/etherpad-webcomponents/EpColorPicker.js';
+import '@samtv12345/etherpad-webcomponents/EpDropdown.js';
+import '@samtv12345/etherpad-webcomponents/EpToolbarSelect.js';
+import '@samtv12345/etherpad-webcomponents/EpCheckbox.js';
 import './EpPluginToolbar';
 
-export {EpNotification} from 'etherpad-webcomponents';
-export {EpModal} from 'etherpad-webcomponents';
-export {EpToastContainer} from 'etherpad-webcomponents';
-export {EpColorPicker} from 'etherpad-webcomponents';
-export {EpDropdown, EpDropdownItem} from 'etherpad-webcomponents';
+export {EpNotification} from '@samtv12345/etherpad-webcomponents';
+export {EpModal} from '@samtv12345/etherpad-webcomponents';
+export {EpToastContainer} from '@samtv12345/etherpad-webcomponents';
+export {EpColorPicker} from '@samtv12345/etherpad-webcomponents';
+export {EpDropdown, EpDropdownItem} from '@samtv12345/etherpad-webcomponents';
 export {EpPluginToolbar} from './EpPluginToolbar';
-export {EpToolbarSelect} from 'etherpad-webcomponents';
+export {EpToolbarSelect} from '@samtv12345/etherpad-webcomponents';

--- a/ui/src/js/core/ComponentBridge.ts
+++ b/ui/src/js/core/ComponentBridge.ts
@@ -1,5 +1,5 @@
 import { editorBus } from './EventBus'
-import { EpNotification, EpToastContainer } from 'etherpad-webcomponents'
+import { EpNotification, EpToastContainer } from '@samtv12345/etherpad-webcomponents'
 
 // Initialize toast container
 const toasts = EpToastContainer.getInstance()

--- a/ui/src/js/notifications.ts
+++ b/ui/src/js/notifications.ts
@@ -1,5 +1,5 @@
-import 'etherpad-webcomponents/EpNotification.js'
-import { EpNotification } from 'etherpad-webcomponents'
+import '@samtv12345/etherpad-webcomponents/EpNotification.js'
+import { EpNotification } from '@samtv12345/etherpad-webcomponents'
 
 export const notifications = {
   add(args: { title?: string; text: string | Node; class_name?: string; sticky?: boolean; time?: number; position?: 'top' | 'bottom' }): EpNotification {

--- a/ui/src/js/pad_userlist.ts
+++ b/ui/src/js/pad_userlist.ts
@@ -18,7 +18,7 @@ import padutils from './pad_utils';
 import {editorBus} from './core';
 import html10n from './i18n';
 import {pad} from "./pad.ts";
-import 'etherpad-webcomponents/EpUserBadge.js';
+import '@samtv12345/etherpad-webcomponents/EpUserBadge.js';
 
 let myUserInfo: Record<string, any> = {};
 

--- a/ui/src/welcome.ts
+++ b/ui/src/welcome.ts
@@ -1,4 +1,4 @@
 import './js/l10n';
 import './js/index';
-import 'etherpad-webcomponents/EpButton.js'
-import 'etherpad-webcomponents/EpInput.js'
+import '@samtv12345/etherpad-webcomponents/EpButton.js'
+import '@samtv12345/etherpad-webcomponents/EpInput.js'


### PR DESCRIPTION
## What

Repoint the editor web components dependency to **`@samtv12345/etherpad-webcomponents@0.0.13`** on public npm, which carries the **undo-coalescing fix** (typing runs that straddle the `handleKeyEvent`/`idleWorkTimer` incorporation paths now collapse into one undo step, so a single Ctrl+Z fully undoes a word — fixes the flaky `undo` playwright spec on the slower ubuntu runner).

## Why the new name

The unscoped `etherpad-webcomponents` on npm is owned by another account (publishing 404'd), and GitHub Packages requires an auth token even for *public* installs. Publishing under the maintainer's own public scope (`@samtv12345`, via npm **trusted publishing** / OIDC — no stored token) gives **zero-auth installs for everyone**: CI, dependabot, and contributors all just `pnpm install`.

## Changes
- Imports in `ui/src` (7 files), `ui/package.json`, root `package.json`, and the `pnpm-workspace.yaml` override → `@samtv12345/etherpad-webcomponents@^0.0.13`.
- Lockfile regenerated; `pnpm install --frozen-lockfile` passes.
- **No `.npmrc`, no `NODE_AUTH_TOKEN` in CI** — public npm needs none.
- `minimumReleaseAgeExclude` for `@samtv12345/etherpad-webcomponents@0.0.13` so CI's pnpm release-age gate accepts the freshly-published version (removable once it's >24h old).

Verified locally: UI build resolves the scoped package and bundles the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
