### PR TITLE
chore(db): migrate from MySQL to MariaDB in tests and CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,17 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 12
-      mysql:
-        image: mysql:9.6
+      mariadb:
+        image: mariadb:lts
         env:
-          MYSQL_PASSWORD: test_password
-          MYSQL_ROOT_PASSWORD: test_password
-          MYSQL_USER: test_user
-          MYSQL_DATABASE: test_db
+          MARIADB_PASSWORD: test_password
+          MARIADB_ROOT_PASSWORD: test_password
+          MARIADB_USER: test_user
+          MARIADB_DATABASE: test_db
         ports:
           - 3306:3306
         options: >-
-          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -ptest_password --silent"
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 20

--- a/lib/migration/sqldatabase_test.go
+++ b/lib/migration/sqldatabase_test.go
@@ -227,13 +227,13 @@ func setupMySQLContainer(t *testing.T) *TestContainerConfig {
 
 		ctx := context.Background()
 		container, err := testcontainers.Run(
-			ctx, "mysql:9.6",
+			ctx, "mariadb:lts",
 			testcontainers.WithExposedPorts("3306/tcp"),
 			testcontainers.WithEnv(map[string]string{
-				"MYSQL_PASSWORD":      testDbPass,
-				"MYSQL_ROOT_PASSWORD": testDbPass,
-				"MYSQL_USER":          testDbUser,
-				"MYSQL_DATABASE":      testDbName,
+				"MARIADB_PASSWORD":      testDbPass,
+				"MARIADB_ROOT_PASSWORD": testDbPass,
+				"MARIADB_USER":          testDbUser,
+				"MARIADB_DATABASE":      testDbName,
 			}),
 		)
 		if err != nil {

--- a/lib/migration/test_helpers_test.go
+++ b/lib/migration/test_helpers_test.go
@@ -326,13 +326,13 @@ func startMySQL(t *testing.T) (*sql.DB, func()) {
 		waitForMySQLReady(t, host, port)
 	} else {
 		req := testcontainers.ContainerRequest{
-			Image:        "mysql:9.6",
+			Image:        "mariadb:lts",
 			ExposedPorts: []string{"3306/tcp"},
 			Env: map[string]string{
-				"MYSQL_PASSWORD":      testDbPass,
-				"MYSQL_ROOT_PASSWORD": testDbPass,
-				"MYSQL_USER":          testDbUser,
-				"MYSQL_DATABASE":      testDbName,
+				"MARIADB_PASSWORD":      testDbPass,
+				"MARIADB_ROOT_PASSWORD": testDbPass,
+				"MARIADB_USER":          testDbUser,
+				"MARIADB_DATABASE":      testDbName,
 			},
 			WaitingFor: wait.ForLog("ready for connections"),
 		}

--- a/lib/test/testutils/dbUtils_test_helper.go
+++ b/lib/test/testutils/dbUtils_test_helper.go
@@ -534,17 +534,17 @@ func PreparePostgresDB() (*TestContainerConfiguration, error) {
 
 func PrepareMySQLDB() (*TestContainerConfiguration, error) {
 	var env = map[string]string{
-		"MYSQL_PASSWORD":      DbPass,
-		"MYSQL_ROOT_PASSWORD": DbPass,
-		"MYSQL_USER":          DbUser,
-		"MYSQL_DATABASE":      DbName,
+		"MARIADB_PASSWORD":      DbPass,
+		"MARIADB_ROOT_PASSWORD": DbPass,
+		"MARIADB_USER":          DbUser,
+		"MARIADB_DATABASE":      DbName,
 	}
 	ctx := context.Background()
 
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Name:         "etherpad-test-mysql",
-			Image:        "mysql:9.6",
+			Image:        "mariadb:lts",
 			ExposedPorts: []string{"3306/tcp"},
 			Env:          env,
 		},


### PR DESCRIPTION
Replaced MySQL with MariaDB (lts) in `.github/workflows/build.yml` and test utilities. Updated environment variable names and health check commands accordingly.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
