### PR TITLE
feat(security): DB-backed rotating OIDC global secret (SecretRotator)

### DIFF
--- a/lib/api/oidc/authenticator.go
+++ b/lib/api/oidc/authenticator.go
@@ -11,12 +11,14 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/ether/etherpad-go/assets/login"
 	"github.com/ether/etherpad-go/lib/api/constants"
 	db "github.com/ether/etherpad-go/lib/db"
 	"github.com/ether/etherpad-go/lib/models/oidc"
+	"github.com/ether/etherpad-go/lib/security"
 	"github.com/ether/etherpad-go/lib/settings"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
@@ -27,10 +29,14 @@ import (
 )
 
 type Authenticator struct {
+	// provider is rebuilt whenever the SecretRotator rotates the global HMAC
+	// secret, so it is guarded by mu. Read it via currentProvider().
+	mu                sync.RWMutex
 	provider          fosite.OAuth2Provider
 	store             *MemoryStore
 	privateKey        *rsa.PrivateKey
 	retrievedSettings *settings.Settings
+	rotator           *security.SecretRotator
 }
 
 func NewAuthenticator(retrievedSettings *settings.Settings, persistence db.DataStore) *Authenticator {
@@ -79,11 +85,6 @@ func NewAuthenticator(retrievedSettings *settings.Settings, persistence db.DataS
 		}
 	}
 
-	secret := []byte("some-cool-secret-that-is-32bytes")
-	config := &fosite.Config{
-		AccessTokenLifespan: time.Minute * 30,
-		GlobalSecret:        secret,
-	}
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	privateKey, err := loadOrCreatePrivateKey(persistence, privateKey)
 	if err != nil {
@@ -93,13 +94,74 @@ func NewAuthenticator(retrievedSettings *settings.Settings, persistence db.DataS
 		log.Fatalf("Error loading oidc store snapshot: %v", err)
 	}
 
-	var oauth2 = compose.ComposeAllEnabled(config, store, privateKey)
-
-	return &Authenticator{
-		provider:          oauth2,
+	a := &Authenticator{
 		store:             store,
 		privateKey:        privateKey,
 		retrievedSettings: retrievedSettings,
+	}
+
+	// The fosite GlobalSecret (used to HMAC short-lived artifacts such as
+	// authorize codes) was previously hard-coded. It is now a randomly
+	// generated, database-persisted secret that rotates on the configured
+	// cookie key-rotation interval. Old secrets remain valid for verification
+	// for the session lifetime so in-flight artifacts keep working across a
+	// rotation. See lib/security/secretrotator.go.
+	interval := time.Duration(retrievedSettings.Cookie.KeyRotationInterval) * time.Millisecond
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	lifetime := time.Duration(retrievedSettings.Cookie.SessionLifetime) * time.Millisecond
+	if lifetime <= 0 {
+		lifetime = interval
+	}
+	a.rotator = security.NewSecretRotator(persistence, "oidc_global_secret", interval, lifetime, nil, nil)
+	a.rotator.OnRotate(a.rebuildProvider)
+	if err := a.rotator.Start(); err != nil {
+		log.Fatalf("Error starting oidc secret rotator: %v", err)
+	}
+	// Start triggers the first update which fires OnRotate -> rebuildProvider,
+	// but guard against an empty provider just in case.
+	if a.currentProvider() == nil {
+		a.rebuildProvider()
+	}
+	return a
+}
+
+// rebuildProvider composes a fresh OAuth2 provider using the rotator's current
+// secrets. A brand-new fosite.Config is built each time (never mutated in
+// place) so that requests holding an older provider keep reading a consistent
+// secret. Invoked on startup and on every rotation.
+func (a *Authenticator) rebuildProvider() {
+	secrets := a.rotator.Secrets()
+	var global []byte
+	var rotated [][]byte
+	if len(secrets) > 0 {
+		global = secrets[0]
+		rotated = secrets[1:]
+	}
+	cfg := &fosite.Config{
+		AccessTokenLifespan:  time.Minute * 30,
+		GlobalSecret:         global,
+		RotatedGlobalSecrets: rotated,
+	}
+	prov := compose.ComposeAllEnabled(cfg, a.store, a.privateKey)
+	a.mu.Lock()
+	a.provider = prov
+	a.mu.Unlock()
+}
+
+// currentProvider returns the active OAuth2 provider. Capture it once per
+// request so a concurrent rotation cannot swap the provider mid-handler.
+func (a *Authenticator) currentProvider() fosite.OAuth2Provider {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.provider
+}
+
+// Stop halts the background secret rotation. Call during server shutdown.
+func (a *Authenticator) Stop() {
+	if a.rotator != nil {
+		a.rotator.Stop()
 	}
 }
 
@@ -179,26 +241,28 @@ func (a *Authenticator) JwksEndpoint(rw http.ResponseWriter, req *http.Request) 
 
 func (a *Authenticator) IntrospectionEndpoint(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	provider := a.currentProvider()
 	mySessionData := a.newSession(nil, "")
-	ir, err := a.provider.NewIntrospectionRequest(ctx, req, mySessionData)
+	ir, err := provider.NewIntrospectionRequest(ctx, req, mySessionData)
 	if err != nil {
 		log.Printf("Error occurred in NewIntrospectionRequest: %+v", err)
-		a.provider.WriteIntrospectionError(ctx, rw, err)
+		provider.WriteIntrospectionError(ctx, rw, err)
 		return
 	}
-	a.provider.WriteIntrospectionResponse(ctx, rw, ir)
+	provider.WriteIntrospectionResponse(ctx, rw, ir)
 }
 
 func (a *Authenticator) TokenEndpoint(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	provider := a.currentProvider()
 	clientId := req.Form.Get("client_id")
 
 	mySessionData := a.newSession(nil, clientId)
 
-	accessRequest, err := a.provider.NewAccessRequest(ctx, req, mySessionData)
+	accessRequest, err := provider.NewAccessRequest(ctx, req, mySessionData)
 	if err != nil {
 		log.Printf("Error occurred in NewAccessRequest: %+v", err)
-		a.provider.WriteAccessError(ctx, rw, accessRequest, err)
+		provider.WriteAccessError(ctx, rw, accessRequest, err)
 		return
 	}
 
@@ -208,25 +272,26 @@ func (a *Authenticator) TokenEndpoint(rw http.ResponseWriter, req *http.Request)
 		}
 	}
 
-	response, err := a.provider.NewAccessResponse(ctx, accessRequest)
+	response, err := provider.NewAccessResponse(ctx, accessRequest)
 	if err != nil {
 		log.Printf("Error occurred in NewAccessResponse: %+v", err)
-		a.provider.WriteAccessError(ctx, rw, accessRequest, err)
+		provider.WriteAccessError(ctx, rw, accessRequest, err)
 		return
 	}
 
-	a.provider.WriteAccessResponse(ctx, rw, accessRequest, response)
+	provider.WriteAccessResponse(ctx, rw, accessRequest, response)
 }
 
 func (a *Authenticator) RevokeEndpoint(rw http.ResponseWriter, req *http.Request) {
 	// This context will be passed to all methods.
 	ctx := req.Context()
+	provider := a.currentProvider()
 
 	// This will accept the token revocation request and validate various parameters.
-	err := a.provider.NewRevocationRequest(ctx, req)
+	err := provider.NewRevocationRequest(ctx, req)
 
 	// All done, send the response.
-	a.provider.WriteRevocationResponse(ctx, rw, err)
+	provider.WriteRevocationResponse(ctx, rw, err)
 }
 
 func (a *Authenticator) OicWellKnown(rw http.ResponseWriter, req *http.Request, retrievedSettings *settings.Settings) {
@@ -320,12 +385,13 @@ func renderLoginPage(rw http.ResponseWriter, req *http.Request, clients []settin
 
 func (a *Authenticator) AuthEndpoint(rw http.ResponseWriter, req *http.Request, setupLogger *zap.SugaredLogger, retrievedSettings *settings.Settings) {
 	ctx := req.Context()
+	provider := a.currentProvider()
 	req.ParseForm()
 
-	ar, err := a.provider.NewAuthorizeRequest(ctx, req)
+	ar, err := provider.NewAuthorizeRequest(ctx, req)
 	if err != nil {
 		setupLogger.Error("Error occurred in NewAuthorizeRequest: ", err)
-		a.provider.WriteAuthorizeError(ctx, rw, ar, err)
+		provider.WriteAuthorizeError(ctx, rw, ar, err)
 		return
 	}
 	hydrateAuthorizeRequestForm(req, ar)
@@ -352,13 +418,13 @@ func (a *Authenticator) AuthEndpoint(rw http.ResponseWriter, req *http.Request, 
 	}
 
 	mySessionData := a.newSession(&user, clientId)
-	response, err := a.provider.NewAuthorizeResponse(ctx, ar, mySessionData)
+	response, err := provider.NewAuthorizeResponse(ctx, ar, mySessionData)
 	if err != nil {
 		log.Printf("Error occurred in NewAuthorizeResponse: %+v", err)
-		a.provider.WriteAuthorizeError(ctx, rw, ar, err)
+		provider.WriteAuthorizeError(ctx, rw, ar, err)
 		return
 	}
-	a.provider.WriteAuthorizeResponse(ctx, rw, ar, response)
+	provider.WriteAuthorizeResponse(ctx, rw, ar, response)
 }
 
 func (a *Authenticator) newSession(user *MemoryUserRelation, clientId string) *openid.DefaultSession {

--- a/lib/db/DataStore.go
+++ b/lib/db/DataStore.go
@@ -120,6 +120,19 @@ type OIDCMethods interface {
 	DeleteOIDCSession(signature string) error
 }
 
+// SecretMethods back the SecretRotator. Each published parameter set is
+// addressed by a random id within a rotator namespace (prefix), allowing
+// several rotators (and several Etherpad instances) to coexist in one table.
+type SecretMethods interface {
+	// SaveSecretParams upserts one published parameter set.
+	SaveSecretParams(id string, prefix string, payload string) error
+	// ListSecretParams returns all parameter sets for the given prefix as a
+	// map of id -> payload.
+	ListSecretParams(prefix string) (map[string]string, error)
+	// DeleteSecretParams removes a single parameter set by id.
+	DeleteSecretParams(id string) error
+}
+
 type DataStore interface {
 	PadMethods
 	AuthorMethods
@@ -128,6 +141,7 @@ type DataStore interface {
 	ChatMethods
 	ServerMethods
 	OIDCMethods
+	SecretMethods
 	Close() error
 	Ping() error
 }

--- a/lib/db/MemoryDataStore.go
+++ b/lib/db/MemoryDataStore.go
@@ -22,6 +22,7 @@ type MemoryDataStore struct {
 	groupStore    map[string]string
 	serverVersion *db.ServerVersion
 	oidcStorage   map[string]string
+	secretParams  map[string]memorySecretRow
 
 	// oidc
 	accessTokens           map[string]fosite.Requester
@@ -671,6 +672,33 @@ func (m *MemoryDataStore) DeleteOIDCStorageValue(key string) error {
 	return nil
 }
 
+// ============== SECRET ROTATION ==============
+
+type memorySecretRow struct {
+	prefix  string
+	payload string
+}
+
+func (m *MemoryDataStore) SaveSecretParams(id string, prefix string, payload string) error {
+	m.secretParams[id] = memorySecretRow{prefix: prefix, payload: payload}
+	return nil
+}
+
+func (m *MemoryDataStore) ListSecretParams(prefix string) (map[string]string, error) {
+	result := make(map[string]string)
+	for id, row := range m.secretParams {
+		if row.prefix == prefix {
+			result[id] = row.payload
+		}
+	}
+	return result, nil
+}
+
+func (m *MemoryDataStore) DeleteSecretParams(id string) error {
+	delete(m.secretParams, id)
+	return nil
+}
+
 // ============== OAUTH TOKEN TABLE METHODS ==============
 
 // Access tokens
@@ -892,6 +920,7 @@ func NewMemoryDataStore() *MemoryDataStore {
 		sessionStore:           make(map[string]session2.Session),
 		groupStore:             make(map[string]string),
 		oidcStorage:            make(map[string]string),
+		secretParams:           make(map[string]memorySecretRow),
 		accessTokens:           make(map[string]fosite.Requester),
 		accessTokenRequestIDs:  make(map[string]string),
 		refreshTokens:          make(map[string]db.StoreRefreshToken),

--- a/lib/db/MySQLDB.go
+++ b/lib/db/MySQLDB.go
@@ -1110,6 +1110,59 @@ func (d MysqlDB) DeleteOIDCStorageValue(key string) error {
 	return err
 }
 
+// ============== SECRET ROTATION TABLE METHODS ==============
+
+func (d MysqlDB) SaveSecretParams(id string, prefix string, payload string) error {
+	resultedSQL, args, err := mysql.
+		Insert("secret_rotation").
+		Columns("id", "prefix", "payload").
+		Values(id, prefix, payload).
+		Suffix("ON DUPLICATE KEY UPDATE prefix = VALUES(prefix), payload = VALUES(payload)").
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = d.sqlDB.Exec(resultedSQL, args...)
+	return err
+}
+
+func (d MysqlDB) ListSecretParams(prefix string) (map[string]string, error) {
+	resultedSQL, args, err := mysql.
+		Select("id", "payload").
+		From("secret_rotation").
+		Where(sq.Eq{"prefix": prefix}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := d.sqlDB.Query(resultedSQL, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string]string)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return nil, err
+		}
+		result[id] = payload
+	}
+	return result, rows.Err()
+}
+
+func (d MysqlDB) DeleteSecretParams(id string) error {
+	resultedSQL, args, err := mysql.
+		Delete("secret_rotation").
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = d.sqlDB.Exec(resultedSQL, args...)
+	return err
+}
+
 // ============== OAUTH TOKEN TABLE METHODS ==============
 
 // Access tokens

--- a/lib/db/PostgresDB.go
+++ b/lib/db/PostgresDB.go
@@ -887,6 +887,65 @@ func (d PostgresDB) DeleteOIDCStorageValue(key string) error {
 	return err
 }
 
+// ============== SECRET ROTATION TABLE METHODS ==============
+
+func (d PostgresDB) SaveSecretParams(id string, prefix string, payload string) error {
+	ctx := context.Background()
+	sqlStr, args, err := psql.
+		Insert("secret_rotation").
+		Columns("id", "prefix", "payload").
+		Values(id, prefix, payload).
+		Suffix(`ON CONFLICT(id) DO UPDATE SET
+			prefix = excluded.prefix,
+			payload = excluded.payload,
+			updated_at = CURRENT_TIMESTAMP`).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = d.pool.Exec(ctx, sqlStr, args...)
+	return err
+}
+
+func (d PostgresDB) ListSecretParams(prefix string) (map[string]string, error) {
+	ctx := context.Background()
+	sqlStr, args, err := psql.
+		Select("id", "payload").
+		From("secret_rotation").
+		Where(sq.Eq{"prefix": prefix}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := d.pool.Query(ctx, sqlStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string]string)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return nil, err
+		}
+		result[id] = payload
+	}
+	return result, rows.Err()
+}
+
+func (d PostgresDB) DeleteSecretParams(id string) error {
+	ctx := context.Background()
+	sqlStr, args, err := psql.
+		Delete("secret_rotation").
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = d.pool.Exec(ctx, sqlStr, args...)
+	return err
+}
+
 // ============== OAUTH TOKEN TABLE METHODS ==============
 
 // Access tokens

--- a/lib/db/SQLiteDB.go
+++ b/lib/db/SQLiteDB.go
@@ -1129,6 +1129,62 @@ func (d SQLiteDB) DeleteOIDCStorageValue(key string) error {
 	return err
 }
 
+// ============== SECRET ROTATION TABLE METHODS ==============
+
+func (d SQLiteDB) SaveSecretParams(id string, prefix string, payload string) error {
+	resultedSQL, args, err := sq.
+		Insert("secret_rotation").
+		Columns("id", "prefix", "payload").
+		Values(id, prefix, payload).
+		Suffix(`ON CONFLICT(id) DO UPDATE SET
+			prefix = excluded.prefix,
+			payload = excluded.payload,
+			updated_at = CURRENT_TIMESTAMP`).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = d.sqlDB.Exec(resultedSQL, args...)
+	return err
+}
+
+func (d SQLiteDB) ListSecretParams(prefix string) (map[string]string, error) {
+	resultedSQL, args, err := sq.
+		Select("id", "payload").
+		From("secret_rotation").
+		Where(sq.Eq{"prefix": prefix}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := d.sqlDB.Query(resultedSQL, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[string]string)
+	for rows.Next() {
+		var id, payload string
+		if err := rows.Scan(&id, &payload); err != nil {
+			return nil, err
+		}
+		result[id] = payload
+	}
+	return result, rows.Err()
+}
+
+func (d SQLiteDB) DeleteSecretParams(id string) error {
+	resultedSQL, args, err := sq.
+		Delete("secret_rotation").
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = d.sqlDB.Exec(resultedSQL, args...)
+	return err
+}
+
 // ============== OAUTH TOKEN TABLE METHODS ==============
 
 // Access tokens

--- a/lib/db/migrations/001_initial_schema.go
+++ b/lib/db/migrations/001_initial_schema.go
@@ -12,6 +12,7 @@ func GetMigrations() []Migration {
 		migration003OIDCStorage(),
 		migration004OAuthTokens(),
 		migration005LargeTextColumns(),
+		migration006SecretRotation(),
 	}
 }
 

--- a/lib/db/migrations/006_secret_rotation.go
+++ b/lib/db/migrations/006_secret_rotation.go
@@ -1,0 +1,51 @@
+package migrations
+
+import "database/sql"
+
+// migration006SecretRotation creates a dedicated table that backs the
+// SecretRotator. Each row holds one published set of key-derivation
+// parameters (payload) for a given rotator namespace (prefix). Multiple
+// Etherpad instances sharing the same database cooperate through this table.
+func migration006SecretRotation() Migration {
+	return Migration{
+		Version:     6,
+		Description: "Secret rotation - create table for rotated signing secret parameters",
+		Up: func(db *sql.DB, dialect Dialect) error {
+			switch dialect {
+			case DialectMySQL:
+				// MySQL/MariaDB does not support CREATE INDEX IF NOT EXISTS, so
+				// the prefix index is declared inline in the table definition.
+				_, err := db.Exec(`CREATE TABLE IF NOT EXISTS secret_rotation (
+					id VARCHAR(255) PRIMARY KEY,
+					prefix VARCHAR(255) NOT NULL,
+					payload LONGTEXT NOT NULL,
+					updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+					INDEX idx_secret_rotation_prefix (prefix)
+				)`)
+				return err
+			case DialectPostgres:
+				if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS secret_rotation (
+					id TEXT PRIMARY KEY,
+					prefix TEXT NOT NULL,
+					payload TEXT NOT NULL,
+					updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+				)`); err != nil {
+					return err
+				}
+				_, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_secret_rotation_prefix ON secret_rotation (prefix)`)
+				return err
+			default:
+				if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS secret_rotation (
+					id TEXT PRIMARY KEY,
+					prefix TEXT NOT NULL,
+					payload TEXT NOT NULL,
+					updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+				)`); err != nil {
+					return err
+				}
+				_, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_secret_rotation_prefix ON secret_rotation (prefix)`)
+				return err
+			}
+		},
+	}
+}

--- a/lib/security/secretrotator.go
+++ b/lib/security/secretrotator.go
@@ -1,0 +1,426 @@
+// Package security provides the SecretRotator, a port of Etherpad's
+// src/node/security/SecretRotator.ts. It maintains an array of secrets across
+// one or more Etherpad instances sharing the same database, periodically
+// rotating in a new secret and removing the oldest secret.
+//
+// The secrets are generated using a key derivation function (HKDF) with input
+// keying material coming from a long-lived secret stored in the database
+// (generated if missing). The first secret in the array is the one that should
+// be used to generate new MACs/signatures; every secret in the array should be
+// accepted when validating an existing MAC/signature.
+package security
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/crypto/hkdf"
+)
+
+// SecretStore is the persistence contract backing the rotator. *db.DataStore
+// satisfies it through the dedicated secret_rotation table.
+type SecretStore interface {
+	SaveSecretParams(id string, prefix string, payload string) error
+	ListSecretParams(prefix string) (map[string]string, error)
+	DeleteSecretParams(id string) error
+}
+
+// kdfParams holds the persisted parameters for the HKDF algorithm. Secret and
+// salt are hex-encoded random bytes.
+type kdfParams struct {
+	Digest string `json:"digest"`
+	KeyLen int    `json:"keyLen"`
+	Salt   string `json:"salt"`
+	Secret string `json:"secret"`
+}
+
+// algorithm is a key derivation algorithm. Entries in the algorithms slice are
+// addressed by index (algId) which is persisted, so the slice must only ever be
+// appended to (mirrors the upstream comment in SecretRotator.ts).
+type algorithm interface {
+	generateParams() (json.RawMessage, error)
+	derive(algParams json.RawMessage, info string) ([]byte, error)
+}
+
+// legacyStaticSecret (algId 0) returns a fixed secret regardless of info. Its
+// algParams is a JSON string holding the secret itself. Used to migrate an
+// existing static secret into the rotation scheme.
+type legacyStaticSecret struct{}
+
+func (legacyStaticSecret) generateParams() (json.RawMessage, error) {
+	return nil, errors.New("legacyStaticSecret cannot generate params")
+}
+
+func (legacyStaticSecret) derive(algParams json.RawMessage, _ string) ([]byte, error) {
+	var s string
+	if err := json.Unmarshal(algParams, &s); err != nil {
+		return nil, err
+	}
+	return []byte(s), nil
+}
+
+// hkdfAlgorithm (algId 1) derives per-interval secrets from a stored random
+// secret using HKDF, salted per-params and with the interval start time as the
+// info parameter.
+type hkdfAlgorithm struct {
+	keyLen int
+}
+
+func (h hkdfAlgorithm) generateParams() (json.RawMessage, error) {
+	secret := make([]byte, h.keyLen)
+	salt := make([]byte, h.keyLen)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, err
+	}
+	if _, err := rand.Read(salt); err != nil {
+		return nil, err
+	}
+	return json.Marshal(kdfParams{
+		Digest: "sha256",
+		KeyLen: h.keyLen,
+		Salt:   hex.EncodeToString(salt),
+		Secret: hex.EncodeToString(secret),
+	})
+}
+
+func (h hkdfAlgorithm) derive(algParams json.RawMessage, info string) ([]byte, error) {
+	var p kdfParams
+	if err := json.Unmarshal(algParams, &p); err != nil {
+		return nil, err
+	}
+	// secret/salt are hex strings; their literal bytes are used as IKM and salt.
+	// Internal consistency is all that matters (Go-only deployment), so the
+	// exact byte interpretation need not match Node's crypto.hkdf.
+	r := hkdf.New(sha256.New, []byte(p.Secret), []byte(p.Salt), []byte(info))
+	out := make([]byte, p.KeyLen)
+	if _, err := io.ReadFull(r, out); err != nil {
+		return nil, err
+	}
+	// Hex-encode so the active secret is comfortably longer than fosite's 32-byte
+	// minimum and is safe to log/store as text.
+	dst := make([]byte, hex.EncodedLen(len(out)))
+	hex.Encode(dst, out)
+	return dst, nil
+}
+
+// algorithms is append-only. defaultAlgID always points at the last entry.
+var algorithms = []algorithm{
+	legacyStaticSecret{},
+	hkdfAlgorithm{keyLen: 32},
+}
+
+var defaultAlgID = len(algorithms) - 1
+
+// secretParams is one published parameter set. interval is nil for the legacy
+// static secret. All times are unix milliseconds.
+type secretParams struct {
+	AlgID     int             `json:"algId"`
+	AlgParams json.RawMessage `json:"algParams"`
+	Start     int64           `json:"start"`
+	End       int64           `json:"end"`
+	Interval  *int64          `json:"interval"`
+	Lifetime  int64           `json:"lifetime"`
+}
+
+// SecretRotator maintains a rotating array of secrets persisted in the database.
+type SecretRotator struct {
+	mu       sync.RWMutex
+	secrets  [][]byte
+	prefix   string
+	interval int64 // ms
+	lifetime int64 // ms
+	legacy   *string
+
+	store    SecretStore
+	logger   *zap.SugaredLogger
+	nowFn    func() int64 // unix ms; injectable for tests
+	onRotate func()       // optional, invoked after every successful update
+
+	timer   *time.Timer
+	stopped bool
+}
+
+// NewSecretRotator creates a rotator. interval is how often a new secret is
+// rotated in; lifetime is how long after the end of an interval a secret stays
+// usable. legacyStaticSecret, if non-nil, covers the period before the first
+// rotated secret to ease migration from a previously static secret.
+func NewSecretRotator(store SecretStore, prefix string, interval, lifetime time.Duration, legacyStaticSecret *string, logger *zap.SugaredLogger) *SecretRotator {
+	return &SecretRotator{
+		prefix:   prefix,
+		interval: interval.Milliseconds(),
+		lifetime: lifetime.Milliseconds(),
+		legacy:   legacyStaticSecret,
+		store:    store,
+		logger:   logger,
+		nowFn:    func() int64 { return time.Now().UnixMilli() },
+	}
+}
+
+// OnRotate registers a callback invoked after every successful update (initial
+// and each rotation). Must be set before Start.
+func (r *SecretRotator) OnRotate(fn func()) { r.onRotate = fn }
+
+// Secrets returns a snapshot of the active secrets. The first entry is the one
+// to use for generating new MACs/signatures; all entries are valid for
+// verification.
+func (r *SecretRotator) Secrets() [][]byte {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([][]byte, len(r.secrets))
+	copy(out, r.secrets)
+	return out
+}
+
+// Start performs the first update synchronously (so Secrets is populated before
+// use) and schedules subsequent rotations.
+func (r *SecretRotator) Start() error {
+	return r.update()
+}
+
+// Stop cancels the scheduled rotation.
+func (r *SecretRotator) Stop() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stopped = true
+	if r.timer != nil {
+		r.timer.Stop()
+		r.timer = nil
+	}
+}
+
+func mod(a, n int64) int64 { return ((a % n) + n) % n }
+
+func intervalStart(t, interval int64) int64 { return t - mod(t, interval) }
+
+// deriveSecrets derives all relevant secrets for one parameter set as of now.
+func (r *SecretRotator) deriveSecrets(p secretParams, now int64) ([][]byte, error) {
+	alg := algorithms[p.AlgID]
+	if p.Interval == nil {
+		s, err := alg.derive(p.AlgParams, "")
+		if err != nil {
+			return nil, err
+		}
+		return [][]byte{s}, nil
+	}
+	iv := *p.Interval
+	t0 := intervalStart(now, iv)
+	// Start of the first interval covered by these params, backdated by iv to
+	// accommodate clock skew between instances.
+	tA := intervalStart(p.Start-iv, iv)
+	tZ := intervalStart(p.End-1, iv)
+	expired := func(tN int64) bool { return now >= tN+(2*iv)+p.Lifetime }
+
+	start := min(t0, tZ)
+	var tNs []int64
+	// Walk back from start to the start of coverage; t0 must be first so its
+	// derived secret (used to generate new MACs) is secrets[0].
+	for tN := start; tN >= tA && !expired(tN); tN -= iv {
+		tNs = append(tNs, tN)
+	}
+	// Include a future derived secret to accommodate clock skew.
+	if t0+iv <= tZ {
+		tNs = append(tNs, t0+iv)
+	}
+	out := make([][]byte, 0, len(tNs))
+	for _, tN := range tNs {
+		s, err := alg.derive(p.AlgParams, strconv.FormatInt(tN, 10))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// publish writes a parameter set to the database. When id is empty a random id
+// is generated to avoid races with other instances.
+func (r *SecretRotator) publish(p secretParams, id string) (string, error) {
+	if id == "" {
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			return "", err
+		}
+		id = hex.EncodeToString(buf)
+	}
+	payload, err := json.Marshal(p)
+	if err != nil {
+		return "", err
+	}
+	if err := r.store.SaveSecretParams(id, r.prefix, string(payload)); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func marshalString(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+// update reconciles the published parameter sets with the database, derives the
+// active secrets, and schedules the next rotation. It mirrors
+// SecretRotator.ts#_update.
+func (r *SecretRotator) update() error {
+	now := r.nowFn()
+	t0 := intervalStart(now, r.interval)
+	next := t0 + r.interval
+	legacyEnd := now
+
+	dbMap, err := r.store.ListSecretParams(r.prefix)
+	if err != nil {
+		return err
+	}
+
+	var currentParams *secretParams
+	currentID := ""
+	var allParams []secretParams
+	var legacyParams []secretParams
+
+	for id, payload := range dbMap {
+		var p secretParams
+		if err := json.Unmarshal([]byte(payload), &p); err != nil {
+			if r.logger != nil {
+				r.logger.Warnf("secret-rotation %s: dropping unparseable params %s: %v", r.prefix, id, err)
+			}
+			continue
+		}
+		if p.AlgID == 0 && r.legacy != nil {
+			var s string
+			if err := json.Unmarshal(p.AlgParams, &s); err == nil && s == *r.legacy {
+				legacyParams = append(legacyParams, p)
+			}
+		}
+		if p.Start < legacyEnd {
+			legacyEnd = p.Start
+		}
+
+		pInterval := r.interval
+		if p.Interval != nil {
+			pInterval = *p.Interval
+		}
+		// Expired: a MAC derived from these params can no longer be valid.
+		if now >= p.End+p.Lifetime+pInterval {
+			if err := r.store.DeleteSecretParams(id); err != nil && r.logger != nil {
+				r.logger.Warnf("secret-rotation %s: failed to remove expired params %s: %v", r.prefix, id, err)
+			}
+			continue
+		}
+
+		hasInterval := p.Interval != nil
+		var t1 int64
+		if hasInterval {
+			t1 = intervalStart(now, *p.Interval) + *p.Interval
+			if t1 < next {
+				next = t1
+			}
+		}
+		if hasInterval {
+			tA := intervalStart(p.Start, *p.Interval)
+			if *p.Interval == r.interval && p.Lifetime == r.lifetime &&
+				tA <= t1 && p.End > now &&
+				(currentParams == nil || p.Start > currentParams.Start) {
+				if currentParams != nil {
+					allParams = append(allParams, *currentParams)
+				}
+				cp := p
+				currentParams = &cp
+				currentID = id
+				continue
+			}
+		}
+		allParams = append(allParams, p)
+	}
+
+	// Cover the gap before the first rotated secret with the legacy static
+	// secret, if one was supplied and nothing already covers it.
+	if r.legacy != nil && now < legacyEnd+r.lifetime+r.interval &&
+		!legacyCovered(legacyParams, legacyEnd, r.lifetime) {
+		p := secretParams{
+			AlgID:     0,
+			AlgParams: marshalString(*r.legacy),
+			Start:     legacyEnd,
+			End:       legacyEnd,
+			Interval:  nil,
+			Lifetime:  r.lifetime,
+		}
+		allParams = append(allParams, p)
+		if _, err := r.publish(p, ""); err != nil && r.logger != nil {
+			r.logger.Warnf("secret-rotation %s: failed to publish legacy params: %v", r.prefix, err)
+		}
+	}
+
+	if currentParams == nil {
+		algParams, err := algorithms[defaultAlgID].generateParams()
+		if err != nil {
+			return err
+		}
+		iv := r.interval
+		currentParams = &secretParams{
+			AlgID:     defaultAlgID,
+			AlgParams: algParams,
+			Start:     now,
+			End:       now, // extended below
+			Interval:  &iv,
+			Lifetime:  r.lifetime,
+		}
+	}
+	// Advance expiration to the end of the next interval so params never expire
+	// under normal operation. Must happen before deriving secrets.
+	currentParams.End = max(currentParams.End, t0+(2*r.interval))
+	if _, err := r.publish(*currentParams, currentID); err != nil && r.logger != nil {
+		r.logger.Warnf("secret-rotation %s: failed to publish current params: %v", r.prefix, err)
+	}
+
+	// Secrets derived from currentParams MUST come first.
+	secrets, err := r.deriveSecrets(*currentParams, now)
+	if err != nil {
+		return err
+	}
+	for _, p := range allParams {
+		s, err := r.deriveSecrets(p, now)
+		if err != nil {
+			return err
+		}
+		secrets = append(secrets, s...)
+	}
+
+	r.mu.Lock()
+	r.secrets = secrets
+	stopped := r.stopped
+	if !stopped {
+		delay := max(next-r.nowFn(), 0)
+		r.timer = time.AfterFunc(time.Duration(delay)*time.Millisecond, func() {
+			if err := r.update(); err != nil && r.logger != nil {
+				r.logger.Warnf("secret-rotation %s: scheduled update failed: %v", r.prefix, err)
+			}
+		})
+	}
+	r.mu.Unlock()
+
+	if r.logger != nil {
+		r.logger.Debugf("secret-rotation %s: %d active secret(s)", r.prefix, len(secrets))
+	}
+	if r.onRotate != nil {
+		r.onRotate()
+	}
+	return nil
+}
+
+// legacyCovered reports whether an existing legacy params set already covers the
+// period ending at legacyEnd+lifetime.
+func legacyCovered(legacyParams []secretParams, legacyEnd, lifetime int64) bool {
+	for _, p := range legacyParams {
+		if p.End+p.Lifetime >= legacyEnd+lifetime {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/security/secretrotator.go
+++ b/lib/security/secretrotator.go
@@ -11,11 +11,13 @@
 package security
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -96,6 +98,9 @@ func (h hkdfAlgorithm) derive(algParams json.RawMessage, info string) ([]byte, e
 	if err := json.Unmarshal(algParams, &p); err != nil {
 		return nil, err
 	}
+	if p.KeyLen <= 0 || p.KeyLen > 1024 {
+		return nil, fmt.Errorf("invalid hkdf keyLen %d", p.KeyLen)
+	}
 	// secret/salt are hex strings; their literal bytes are used as IKM and salt.
 	// Internal consistency is all that matters (Go-only deployment), so the
 	// exact byte interpretation need not match Node's crypto.hkdf.
@@ -175,13 +180,23 @@ func (r *SecretRotator) Secrets() [][]byte {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	out := make([][]byte, len(r.secrets))
-	copy(out, r.secrets)
+	for i, s := range r.secrets {
+		// Deep-copy each secret so callers cannot mutate the rotator's internal
+		// signing/verification material.
+		out[i] = bytes.Clone(s)
+	}
 	return out
 }
 
 // Start performs the first update synchronously (so Secrets is populated before
 // use) and schedules subsequent rotations.
 func (r *SecretRotator) Start() error {
+	if r.interval <= 0 {
+		return fmt.Errorf("secret rotator interval must be positive, got %d ms", r.interval)
+	}
+	if r.lifetime < 0 {
+		return fmt.Errorf("secret rotator lifetime must not be negative, got %d ms", r.lifetime)
+	}
 	return r.update()
 }
 
@@ -289,6 +304,19 @@ func (r *SecretRotator) update() error {
 		if err := json.Unmarshal([]byte(payload), &p); err != nil {
 			if r.logger != nil {
 				r.logger.Warnf("secret-rotation %s: dropping unparseable params %s: %v", r.prefix, id, err)
+			}
+			continue
+		}
+		// Defend against corrupted/tampered rows: an out-of-range algId would
+		// index past `algorithms`, and a non-positive interval would divide by
+		// zero in intervalStart(). Skip such rows so a bad row can never crash a
+		// scheduled rotation.
+		if !validParams(p) {
+			if r.logger != nil {
+				r.logger.Warnf("secret-rotation %s: dropping invalid params %s (algId=%d)", r.prefix, id, p.AlgID)
+			}
+			if err := r.store.DeleteSecretParams(id); err != nil && r.logger != nil {
+				r.logger.Warnf("secret-rotation %s: failed to remove invalid params %s: %v", r.prefix, id, err)
 			}
 			continue
 		}
@@ -412,6 +440,22 @@ func (r *SecretRotator) update() error {
 		r.onRotate()
 	}
 	return nil
+}
+
+// validParams reports whether a persisted parameter set is safe to use. It
+// guards the two values consumed without further checks downstream: AlgID
+// (indexes the algorithms slice) and Interval (used as a modulo divisor).
+func validParams(p secretParams) bool {
+	if p.AlgID < 0 || p.AlgID >= len(algorithms) {
+		return false
+	}
+	if p.Interval != nil && *p.Interval <= 0 {
+		return false
+	}
+	if p.Lifetime < 0 {
+		return false
+	}
+	return true
 }
 
 // legacyCovered reports whether an existing legacy params set already covers the

--- a/lib/security/secretrotator_test.go
+++ b/lib/security/secretrotator_test.go
@@ -1,0 +1,204 @@
+package security
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeStore is an in-memory SecretStore for deterministic tests.
+type fakeStore struct {
+	mu   sync.Mutex
+	data map[string]fakeRow
+}
+
+type fakeRow struct {
+	prefix  string
+	payload string
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{data: map[string]fakeRow{}} }
+
+func (f *fakeStore) SaveSecretParams(id, prefix, payload string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[id] = fakeRow{prefix: prefix, payload: payload}
+	return nil
+}
+
+func (f *fakeStore) ListSecretParams(prefix string) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := map[string]string{}
+	for id, row := range f.data {
+		if row.prefix == prefix {
+			out[id] = row.payload
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) DeleteSecretParams(id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.data, id)
+	return nil
+}
+
+func (f *fakeStore) count(prefix string) int {
+	m, _ := f.ListSecretParams(prefix)
+	return len(m)
+}
+
+// newTestRotator builds a rotator wired to a manual clock and with the
+// background timer disabled so update() can be stepped by hand.
+func newTestRotator(store SecretStore, interval, lifetime time.Duration, now *int64) *SecretRotator {
+	r := NewSecretRotator(store, "test", interval, lifetime, nil, nil)
+	r.nowFn = func() int64 { return *now }
+	r.stopped = true // prevent real timer scheduling in tests
+	return r
+}
+
+func secretsContain(secrets [][]byte, target []byte) bool {
+	for _, s := range secrets {
+		if bytes.Equal(s, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSecretRotator_FirstRunGeneratesSecret(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	r := newTestRotator(store, time.Hour, time.Hour, &now)
+
+	if err := r.update(); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	secrets := r.Secrets()
+	if len(secrets) == 0 {
+		t.Fatal("expected at least one secret")
+	}
+	if len(secrets[0]) < 32 {
+		t.Fatalf("active secret too short for fosite (%d bytes)", len(secrets[0]))
+	}
+	if store.count("test") == 0 {
+		t.Fatal("expected params persisted to store")
+	}
+}
+
+func TestSecretRotator_StableWithinInterval(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	r := newTestRotator(store, time.Hour, time.Hour, &now)
+
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+	first := r.Secrets()[0]
+
+	// Re-running within the same interval must keep the active secret stable.
+	now = int64(time.Minute.Milliseconds() * 10)
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, r.Secrets()[0]) {
+		t.Fatal("active secret changed within the same interval")
+	}
+}
+
+func TestSecretRotator_RotatesAndKeepsOldSecret(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	interval := time.Hour
+	r := newTestRotator(store, interval, time.Hour, &now)
+
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+	old := r.Secrets()[0]
+
+	// Advance one full interval and rotate.
+	now = interval.Milliseconds()
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+	secrets := r.Secrets()
+
+	if bytes.Equal(old, secrets[0]) {
+		t.Fatal("active secret did not rotate after a full interval")
+	}
+	if !secretsContain(secrets, old) {
+		t.Fatal("previous secret dropped from verification window after one interval")
+	}
+}
+
+func TestSecretRotator_MultiInstanceSharesActiveSecret(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+
+	a := newTestRotator(store, time.Hour, time.Hour, &now)
+	if err := a.update(); err != nil {
+		t.Fatal(err)
+	}
+	active := a.Secrets()[0]
+
+	// A second instance starting against the same DB in the same interval must
+	// adopt the already-published current secret rather than minting its own.
+	b := newTestRotator(store, time.Hour, time.Hour, &now)
+	if err := b.update(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(active, b.Secrets()[0]) {
+		t.Fatal("second instance did not adopt the shared active secret")
+	}
+}
+
+func TestSecretRotator_RemovesExpiredParams(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	interval := time.Hour
+	lifetime := time.Hour
+	r := newTestRotator(store, interval, lifetime, &now)
+
+	// Seed a stale params set that ended long ago and is past end+lifetime+interval.
+	iv := interval.Milliseconds()
+	stale := secretParams{
+		AlgID:     1,
+		AlgParams: json.RawMessage(`{"digest":"sha256","keyLen":32,"salt":"00","secret":"00"}`),
+		Start:     -10 * iv,
+		End:       -9 * iv,
+		Interval:  &iv,
+		Lifetime:  lifetime.Milliseconds(),
+	}
+	payload, _ := json.Marshal(stale)
+	if err := store.SaveSecretParams("stale", "test", string(payload)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.data["stale"]; ok {
+		t.Fatal("expired params were not removed from the store")
+	}
+}
+
+func TestSecretRotator_LegacyStaticSecretIncluded(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	legacy := "this-is-a-legacy-static-secret-long-enough"
+	r := NewSecretRotator(store, "test", time.Hour, time.Hour, &legacy, nil)
+	r.nowFn = func() int64 { return now }
+	r.stopped = true
+
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+	if !secretsContain(r.Secrets(), []byte(legacy)) {
+		t.Fatal("legacy static secret not present in active secrets")
+	}
+}

--- a/lib/security/secretrotator_test.go
+++ b/lib/security/secretrotator_test.go
@@ -187,6 +187,65 @@ func TestSecretRotator_RemovesExpiredParams(t *testing.T) {
 	}
 }
 
+func TestSecretRotator_SkipsInvalidParams(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	r := newTestRotator(store, time.Hour, time.Hour, &now)
+
+	// A row with an out-of-range algId and one with interval=0 would otherwise
+	// panic (slice index / divide-by-zero). They must be skipped and removed.
+	badAlg := `{"algId":99,"algParams":{},"start":0,"end":1,"interval":3600000,"lifetime":3600000}`
+	zeroIv := `{"algId":1,"algParams":{"digest":"sha256","keyLen":32,"salt":"00","secret":"00"},"start":0,"end":1,"interval":0,"lifetime":3600000}`
+	if err := store.SaveSecretParams("bad-alg", "test", badAlg); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSecretParams("zero-iv", "test", zeroIv); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.update(); err != nil {
+		t.Fatalf("update must not fail on invalid rows: %v", err)
+	}
+	if _, ok := store.data["bad-alg"]; ok {
+		t.Error("invalid algId row was not removed")
+	}
+	if _, ok := store.data["zero-iv"]; ok {
+		t.Error("zero-interval row was not removed")
+	}
+	// A fresh valid current secret must still have been generated.
+	if len(r.Secrets()) == 0 {
+		t.Error("expected a valid current secret despite invalid rows")
+	}
+}
+
+func TestSecretRotator_SecretsAreDeepCopied(t *testing.T) {
+	store := newFakeStore()
+	now := int64(0)
+	r := newTestRotator(store, time.Hour, time.Hour, &now)
+	if err := r.update(); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := r.Secrets()
+	if len(snap) == 0 || len(snap[0]) == 0 {
+		t.Fatal("expected a non-empty active secret")
+	}
+	// Mutating the returned slice must not affect the rotator's internal secret.
+	snap[0][0] ^= 0xFF
+	if bytes.Equal(snap[0], r.Secrets()[0]) {
+		t.Error("Secrets() returned an aliased slice; caller mutation leaked into rotator state")
+	}
+}
+
+func TestSecretRotator_StartRejectsBadInterval(t *testing.T) {
+	store := newFakeStore()
+	r := NewSecretRotator(store, "test", 0, time.Hour, nil, nil)
+	r.stopped = true
+	if err := r.Start(); err == nil {
+		t.Error("Start should reject a non-positive interval")
+	}
+}
+
 func TestSecretRotator_LegacyStaticSecretIncluded(t *testing.T) {
 	store := newFakeStore()
 	now := int64(0)

--- a/lib/server/server.go
+++ b/lib/server/server.go
@@ -244,6 +244,7 @@ func InitServer(setupLogger *zap.SugaredLogger, uiAssets embed.FS, pluginAssets 
 	<-sigCh
 	setupLogger.Info("Shutting down Etherpad Go...")
 	retrievedHooks.ExecuteShutdownHooks(&events.ShutdownContext{})
+	authenticator.Stop()
 	if err := app.ShutdownWithTimeout(3 * time.Second); err != nil {
 		setupLogger.Warn("Error during shutdown: " + err.Error())
 	}


### PR DESCRIPTION
## What

Replaces the **hard-coded** fosite `GlobalSecret` in the OIDC authenticator (`"some-cool-secret-that-is-32bytes"`) with a randomly generated, database-persisted secret that **rotates** on the configured cookie key-rotation interval. Older secrets stay valid for verification for the session lifetime, so in-flight artifacts keep working across a rotation. Port of etherpad-lite's `SecretRotator`.

## How

- **`lib/security/secretrotator.go`** — HKDF-derived rotating secrets: array of active secrets (first = used to sign, all = accepted for verification), interval rotation + overlapping lifetime window, optional legacy-static-secret migration.
- **Storage** — dedicated `secret_rotation` table (migration 006) + `SecretMethods` on `DataStore`, implemented across SQLite/MySQL/Postgres/Memory via squirrel. MySQL declares the prefix index **inline** in `CREATE TABLE` (no `CREATE INDEX IF NOT EXISTS`).
- **Wiring** — `lib/api/oidc/authenticator.go`: each rotation rebuilds the fosite provider under an `RWMutex` with a **fresh `*fosite.Config`** (never mutated in place → race-free); endpoints read via `currentProvider()`; `Stop()` on shutdown.

## Testing

White-box tests in `lib/security` (rotation, overlapping window, multi-instance, expiry, legacy secret). `go build ./...`, `go vet`, and DB/OIDC tests green (incl. MySQL/Postgres containers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
