### PR TITLE
fix(sheet): follow-up fixes for live presence (#311)

### DIFF
--- a/playwright/specs/sheet_presence.spec.ts
+++ b/playwright/specs/sheet_presence.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// 0-based cell locator. Row header is th (child 1), so data column c is
+// td:nth-child(c + 2); data row r is tbody tr:nth-child(r + 1).
+const cell = (page: Page, r: number, c: number) =>
+  page.locator(`.sheet-grid tbody tr:nth-child(${r + 1}) td:nth-child(${c + 2})`);
+
+async function openSheet(page: Page, padId: string): Promise<void> {
+  await page.goto(`/s/${padId}`);
+  await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+}
+
+async function commitCell(page: Page, r: number, c: number, text: string): Promise<void> {
+  await cell(page, r, c).click();
+  await page.keyboard.type(text, { delay: 30 });
+  await page.keyboard.press('Enter');
+}
+
+test.describe('Sheet live presence & live calculation', () => {
+  test('cursor presence and live calculation across two sessions', async ({ browser }) => {
+    test.setTimeout(120000);
+    const padId = `sheet-presence-${Date.now()}`;
+
+    // Session A sets up A1=10 and C2==B2+1.
+    const ctxA = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    await openSheet(pageA, padId);
+    await commitCell(pageA, 0, 0, '10');     // A1
+    await commitCell(pageA, 1, 2, '=B2+1');  // C2
+
+    // Session B joins and sees the committed value.
+    const ctxB = await browser.newContext();
+    const pageB = await ctxB.newPage();
+    await openSheet(pageB, padId);
+    await expect(cell(pageB, 0, 0)).toHaveText('10', { timeout: 20000 });
+
+    // A focuses B2 -> B sees a remote cursor tag on B2.
+    await cell(pageA, 1, 1).click();
+    await expect(cell(pageB, 1, 1).locator('.sheet-remote-tag')).toBeVisible({ timeout: 20000 });
+
+    // A types a formula in B2 WITHOUT committing -> B sees the live formula text
+    // in B2 and C2 recomputed to 31, before Enter.
+    await pageA.keyboard.type('=A1*3', { delay: 50 });
+    await expect(cell(pageB, 1, 1)).toHaveText('=A1*3', { timeout: 20000 });
+    await expect(cell(pageB, 1, 2)).toHaveText('31', { timeout: 20000 });
+
+    // A commits -> B2 shows the computed result 30 (overlay replaced).
+    await pageA.keyboard.press('Enter');
+    await expect(cell(pageB, 1, 1)).toHaveText('30', { timeout: 20000 });
+
+    // A disconnects -> A's cursor tag disappears on B (reused USER_LEAVE).
+    await ctxA.close();
+    await expect(cell(pageB, 1, 1).locator('.sheet-remote-tag')).toHaveCount(0, { timeout: 20000 });
+
+    await ctxB.close();
+  });
+});

--- a/ui/build.js
+++ b/ui/build.js
@@ -334,6 +334,9 @@ const results = await Promise.allSettled([
   esbuild.build({ ...esbuildOpts, entryPoints: ["./src/pad.js"], outdir: '../assets/js/pad/assets', alias, loader: loaders, logLevel: 'info' }),
   esbuild.build({ ...esbuildOpts, entryPoints: ["./src/welcome.js"], outdir: '../assets/js/welcome/assets', alias, loader: loaders, logLevel: 'info' }),
   esbuild.build({ ...esbuildOpts, entryPoints: ["./src/timeslider.js"], outdir: '../assets/js/timeslider/assets', alias, loader: loaders, logLevel: 'info' }),
+  // entryPoints object form so the output is sheet.js (matches /js/sheet/assets/sheet.js
+  // served by lib/api/pad/sheetFrontend.go), not sheet.entry.js.
+  esbuild.build({ ...esbuildOpts, entryPoints: { sheet: "./src/sheet.entry.ts" }, outdir: '../assets/js/sheet/assets', alias, loader: loaders, logLevel: 'info' }),
   // CSS bundles
   esbuild.build({ ...esbuildOpts, entryPoints: ['../assets/css/skin/colibris/pad.css'], outdir: '../assets/css/build/skin/colibris', external: ['*.woff', '*.woff2', '*.ttf', '*.eot', '*.svg', '*.png', '*.jpg', '*.gif'], loader: loaders, logLevel: 'info' }),
   esbuild.build({ ...esbuildOpts, entryPoints: ['../assets/css/static/pad.css'], outdir: '../assets/css/build/static', external: ['*.woff', '*.woff2', '*.ttf', '*.eot', '*.svg', '*.png', '*.jpg', '*.gif', '/font/*', 'font/*'], loader: loaders, logLevel: 'info' }),

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -122,6 +122,7 @@ export function startSheetEditor(root: HTMLElement): void {
       cols: 20,
       rawValue,
       displayValue,
+      readOnly: data.readonly,
       onEdit: (r, c, raw) => {
         if (!collab) return;
         collab.applyLocal({ type: 'setCell', sheet: activeSheetId, baseRev: collab.rev, row: r, col: c, raw });

--- a/ui/src/js/sheet/sheetPresence.test.ts
+++ b/ui/src/js/sheet/sheetPresence.test.ts
@@ -60,4 +60,14 @@ describe('effectiveCells overlay drives live recompute', () => {
     expect(engine.getValue(1, 2).value).toBe('31'); // C2 = B2+1
     expect(cells.find((c) => c.row === 1 && c.col === 1)?.raw).toBe('=A1*3');
   });
+
+  it('live edit wins over a committed cell at the same coordinate', () => {
+    // The load-bearing overlay property: a remote in-progress raw must REPLACE
+    // the committed raw at the same (row,col), not merely add another entry.
+    const base = [{ row: 1, col: 1, raw: '=A1*99' }];
+    const live = [{ userId: 'a', name: 'A', color: '#f00', sheet: 's1', row: 1, col: 1, raw: '=A1*3' }];
+    const cells = effectiveCells(base, live);
+    expect(cells.filter((c) => c.row === 1 && c.col === 1)).toHaveLength(1);
+    expect(cells.find((c) => c.row === 1 && c.col === 1)?.raw).toBe('=A1*3');
+  });
 });

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -23,6 +23,7 @@ export interface SheetViewOptions {
   onSelect?: (row: number, col: number) => void;
   onLiveEdit?: (row: number, col: number, raw: string) => void;
   onEditEnd?: (row: number, col: number, committed: boolean) => void;
+  readOnly?: boolean;
 }
 
 function colName(c: number): string {
@@ -44,6 +45,7 @@ const CSS = `
 .sheet-grid td { outline: none; position: relative; }
 .sheet-grid td:focus { box-shadow: inset 0 0 0 2px #64d29b; }
 .sheet-remote-tag { position: absolute; top: -15px; left: -1px; font: 10px/14px system-ui, sans-serif; padding: 0 4px; color: #fff; border-radius: 3px 3px 3px 0; white-space: nowrap; z-index: 5; pointer-events: none; }
+.sheet-remote-tag::after { content: attr(data-label); }
 `;
 
 export class DomSheetView {
@@ -83,7 +85,9 @@ export class DomSheetView {
       const rowCells: HTMLTableCellElement[] = [];
       for (let c = 0; c < opts.cols; c++) {
         const td = document.createElement('td');
-        td.contentEditable = 'true';
+        // Read-only viewers get non-editable cells: with no typing, no live-edit
+        // or commit frames originate from the client (the server strips them too).
+        td.contentEditable = opts.readOnly ? 'false' : 'true';
         this.attach(td, r, c);
         tr.appendChild(td);
         rowCells.push(td);
@@ -174,7 +178,9 @@ export class DomSheetView {
           td.style.boxShadow = `inset 0 0 0 2px ${deco.color}`;
           const tag = document.createElement('span');
           tag.className = 'sheet-remote-tag';
-          tag.textContent = deco.name || 'anon';
+          // Label via a CSS ::after pseudo-element (data-label), NOT a text node,
+          // so the peer's name never leaks into the cell's textContent.
+          tag.setAttribute('data-label', deco.name || 'anon');
           tag.style.background = deco.color;
           td.appendChild(tag);
           this.decorated.add(td);

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -44,8 +44,10 @@ export default defineConfig(({ mode }) => {
                 '@': path.resolve(__dirname, '/src'),
             },
         },
-        plugins: [
-            commonjs(),
-        ],
+        // rolldown-vite (v8) handles CommonJS natively. The @rollup/plugin-commonjs
+        // plugin deadlocks the rolldown transform while bundling HyperFormula, so it
+        // is skipped for the sheet entry (rolldown's native CJS handling covers it).
+        // Other entries still load it unchanged.
+        plugins: mode === 'sheet' ? [] : [commonjs()],
     };
 });


### PR DESCRIPTION
Follow-up to **#311** (live presence & live calculation), which auto-merged at an earlier state. This PR delivers the fixes that landed afterward.

## Fixes

- **Build (`ui/vite.config.ts`)** — skip `@rollup/plugin-commonjs` for the `sheet` entry. vite 8 is rolldown-based and handles CommonJS natively; the legacy plugin **deadlocks the rolldown transform** while bundling HyperFormula, so `vite build --mode sheet` hangs and the sheet bundle never builds locally. Other entries are unchanged.
- **Tag-pollution bug (`sheetView.ts`)** — the presence name tag was a child text node of the cell, so a peer's name leaked into the cell's `textContent` (e.g. `=A1*3anon`). Now rendered via a CSS `::after`/`data-label` pseudo-element, leaving the cell content clean.
- **Client-side read-only (`sheetView.ts` / `sheetEditor.ts`)** — honor `data.readonly`: read-only viewers get non-editable cells, so no live-edit/commit frames originate from a viewer (the server already strips/rejects them). Closes the design's "enforced on both client and server" gap and the type-then-revert UX.

## Tests
- **Playwright E2E** (`playwright/specs/sheet_presence.spec.ts`) — two sessions: remote cursor tag, live formula text, dependent `C2 = 31` **before** Enter, `B2 = 30` after commit, cursor cleanup on disconnect. ✅
- **vitest** — direct unit test for the load-bearing `effectiveCells` property (a remote live raw *replaces* a committed cell at the same coordinate). Suite 30/30.

Verified locally: sheet `tsc` clean, vitest 30/30, E2E passing on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
