### PR TITLE
fix(sheet/ws): typed text lost to fill-handle span; raw frame rebroadcast; rate limiter drops commits

### DIFF
--- a/lib/ws/client.go
+++ b/lib/ws/client.go
@@ -129,13 +129,20 @@ func (c *Client) readPump(retrievedSettings *settings.Settings, logger *zap.Suga
 			c.Handler.HandleDisconnectOfPadClient(c, retrievedSettings, logger)
 			break
 		}
-		retrievedSettings.CommitRateLimiting.LoadTest = retrievedSettings.LoadTest
-		if err := ratelimiter.CheckRateLimit(ratelimiter.IPAddress(c.ClientIP), retrievedSettings.CommitRateLimiting); err != nil {
-			logger.Warn("Rate limit exceeded:", err.Error())
-			continue
-		}
 		message = bytes.TrimSpace(bytes.Replace(message, newline, space, -1))
 		decodedMessage := string(message[:])
+
+		// CommitRateLimiting only covers commits (USER_CHANGES / SHEET_OP), as
+		// in etherpad-lite. Ephemeral traffic like SHEET_PRESENCE arrives per
+		// keystroke and must not burn the commit budget — a drained budget
+		// silently drops the commit itself and edits are lost.
+		if strings.Contains(decodedMessage, "USER_CHANGES") || strings.Contains(decodedMessage, "SHEET_OP") {
+			retrievedSettings.CommitRateLimiting.LoadTest = retrievedSettings.LoadTest
+			if err := ratelimiter.CheckRateLimit(ratelimiter.IPAddress(c.ClientIP), retrievedSettings.CommitRateLimiting); err != nil {
+				logger.Warn("Rate limit exceeded:", err.Error())
+				continue
+			}
+		}
 
 		if strings.Contains(decodedMessage, "CLIENT_READY") {
 			var clientReady ws.ClientReady
@@ -236,8 +243,6 @@ func (c *Client) readPump(retrievedSettings *settings.Settings, logger *zap.Suga
 			}
 			c.Handler.HandleMessage(clientMessage, c, retrievedSettings, logger)
 		}
-
-		c.Hub.Broadcast <- message
 	}
 }
 

--- a/ui/src/js/sheet/sheetPresence.ts
+++ b/ui/src/js/sheet/sheetPresence.ts
@@ -41,6 +41,7 @@ export class SheetPresence {
   }
 
   applyPresence(f: PresenceFrame): void {
+    if (!f.userId) return; // not a server-authored frame (e.g. a relayed echo)
     if (f.userId === this.ownUserId) return; // never render our own cursor
     this.cursors.set(f.userId, {
       userId: f.userId, name: f.name, color: f.color, sheet: f.sheet,

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -46,7 +46,7 @@ const CSS = `
 .sheet-grid td.sheet-sel { background: rgba(100, 210, 155, 0.15); }
 .sheet-grid td.sheet-sel-focus { box-shadow: inset 0 0 0 2px #2f9e6b; }
 .sheet-grid td.sheet-remote-sel { box-shadow: inset 0 0 0 2px var(--rsel, #888); }
-.sheet-fill-handle { position: absolute; right: -4px; bottom: -4px; width: 8px; height: 8px; background: #2f9e6b; border: 1px solid #fff; cursor: crosshair; z-index: 6; }
+.sheet-fill-handle { position: absolute; width: 8px; height: 8px; background: #2f9e6b; border: 1px solid #fff; cursor: crosshair; z-index: 6; }
 .sheet-grid td.sheet-fill-target { box-shadow: inset 0 0 0 1px #2f9e6b; }
 .sheet-grid td.sheet-cell-error { color: #c0392b; }
 `;
@@ -66,14 +66,34 @@ export class DomSheetView {
   private fillSrc: Selection | null = null;
   private fillTarget: Selection | null = null;
   private remoteSel: Array<{ userId: string; color: string; sel: Selection }> = [];
+  // Single fill-handle overlay, positioned over the selection's bottom-right
+  // corner. It lives OUTSIDE the contenteditable tds: a decoration inside an
+  // editable cell races the caret and re-renders can delete typed text.
+  private fillHandle: HTMLSpanElement;
+  private table: HTMLTableElement;
 
   constructor(root: HTMLElement, opts: SheetViewOptions) {
     this.opts = opts;
     this.ensureStyle();
     root.innerHTML = '';
+    if (getComputedStyle(root).position === 'static') root.style.position = 'relative';
 
     const table = document.createElement('table');
     table.className = 'sheet-grid';
+    this.table = table;
+
+    this.fillHandle = document.createElement('span');
+    this.fillHandle.className = 'sheet-fill-handle';
+    this.fillHandle.style.display = 'none';
+    this.fillHandle.addEventListener('mousedown', (e: MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      this.filling = true;
+      this.fillSrc = this.selection;
+      const { r0, c0, r1, c1 } = normalize(this.selection);
+      this.fillTarget = { anchor: { row: r0, col: c0 }, focus: { row: r1, col: c1 } };
+    });
+    root.appendChild(this.fillHandle);
 
     const thead = document.createElement('thead');
     const headRow = document.createElement('tr');
@@ -249,7 +269,6 @@ export class DomSheetView {
       td.classList.remove('sheet-remote-sel', 'sheet-fill-target');
       td.style.removeProperty('--rsel');
       td.querySelector('.sheet-remote-tag')?.remove();
-      td.querySelector('.sheet-fill-handle')?.remove();
     }
     this.decorated.clear();
 
@@ -322,22 +341,18 @@ export class DomSheetView {
       }
     }
 
-    // fill handle at the bottom-right corner of the current selection
+    // fill handle overlay at the bottom-right corner of the current selection.
+    // Hidden while typing (Excel does the same); positioned relative to the
+    // root, so it never touches the contenteditable td's content.
     const { r1, c1 } = normalize(this.selection);
     const brCell = this.cells[r1]?.[c1];
-    if (brCell && !this.opts.readOnly) {
-      const h = document.createElement('span');
-      h.className = 'sheet-fill-handle';
-      h.addEventListener('mousedown', (e: MouseEvent) => {
-        e.stopPropagation();
-        e.preventDefault();
-        this.filling = true;
-        this.fillSrc = this.selection;
-        const { r0, c0, r1, c1 } = normalize(this.selection);
-        this.fillTarget = { anchor: { row: r0, col: c0 }, focus: { row: r1, col: c1 } };
-      });
-      brCell.appendChild(h);
-      this.decorated.add(brCell);
+    const editingBr = this.activeEdit && this.editing?.row === r1 && this.editing?.col === c1;
+    if (brCell && !this.opts.readOnly && !editingBr) {
+      this.fillHandle.style.left = `${this.table.offsetLeft + brCell.offsetLeft + brCell.offsetWidth - 4}px`;
+      this.fillHandle.style.top = `${this.table.offsetTop + brCell.offsetTop + brCell.offsetHeight - 4}px`;
+      this.fillHandle.style.display = '';
+    } else {
+      this.fillHandle.style.display = 'none';
     }
     if (this.fillTarget) {
       const t = normalize(this.fillTarget);


### PR DESCRIPTION
These two commits were pushed to feat/excel-m3-formula-bar after PR #320 had already auto-merged, so they never landed on main. Cherry-picked here unchanged.

- **fix(sheet):** the fill handle lived inside the contenteditable td; typing placed the caret in its absolutely-positioned 8x8 box (text rendered outside the cell, wrapping vertically) and any presence-triggered re-render deleted the span together with the typed text. It is now a single overlay element outside the table, hidden while the cell is actively edited.
- **fix(ws):** readPump rebroadcast every raw client frame to ALL connected clients (leaking session tokens from CLIENT_READY; sheet clients built phantom presence entries from the echoes). Removed — every message type already has a canonical handler.
- **fix(ws):** the commit rate limiter ran per websocket message, so per-keystroke SHEET_PRESENCE frames drained the 10/s budget and the SHEET_OP commit itself was silently dropped (cell text never saved). Limiter now only covers USER_CHANGES and SHEET_OP, matching etherpad-lite commitRateLimiting semantics.

Verified live (two-client Playwright probes): text renders in-cell while typing, survives presence traffic, commits and persists across reload; collaborator sees the final value; fill-drag still works; pad text sync and chat unaffected; zero rate-limit drops in the server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)