### PR TITLE
feat(sheet): Excel M4 — multiple sheets, resize, freeze panes, sort/filter

### DIFF
--- a/docs/superpowers/plans/2026-07-02-excel-m4-structural.md
+++ b/docs/superpowers/plans/2026-07-02-excel-m4-structural.md
@@ -1,0 +1,56 @@
+# M4 — Structural / grid polish (multiple sheets, resize, freeze, sort/filter)
+
+Implements the M4 section of `docs/superpowers/specs/2026-07-01-excel-spreadsheet-design.md`.
+Branch `feat/excel-m4-structural`, stacked on `fix/sheet-typing-ws` (PR #324).
+
+## Ops (Go `lib/sheet` + TS mirror)
+
+- **Sheet list**: `addSheet` (sheet=new id, name, index), `renameSheet`, `deleteSheet`,
+  `moveSheet` (toIndex). Convergence rules: duplicate add = first-wins no-op, deleting
+  the last sheet = no-op, and **any op on a missing sheet is a silent no-op** (a late op
+  after a concurrent `deleteSheet` must not poison the ordered-log replay — this changed
+  `Apply`'s old unknown-sheet error).
+- **`setDimension`** (axis `col`/`row`, index, sizePx 1..4096): sparse
+  `ColWidths`/`RowHeights` maps on `Sheet`; structural insert/delete shifts the maps
+  (in-band deletes drop overrides); `Transform` shifts `setDimension.Index` on the
+  matching axis.
+- **`setFreeze`** (frozenRows/frozenCols, 0|1): per-sheet metadata; arbitrary freeze is
+  the upgrade path.
+- Snapshot round-trips all new metadata (`colWidths`/`rowHeights` JSON objects with
+  stringified indices, `frozenRows`/`frozenCols`).
+
+## View / UI
+
+- Grid grown to **200×52** (`ponytail:` DOM-node-per-cell; virtualization is the upgrade
+  path, comment in `sheetView.ts`).
+- **Resize**: drag grips on the header cells (`.sheet-resizer-col/-row`), live preview,
+  one `setDimension` op on mouseup. Column overrides also relax the per-cell
+  `min-width: 80px` default.
+- **Freeze**: `border-collapse: separate` (sticky drops collapsed borders) with
+  right/bottom-only 1px borders; `.sheet-frozen-r/-c` classes + `--fr-top`/`--fc-left`
+  CSS vars measured at render.
+- **Tabs bar** (`sheetTabs.ts`): click switch, dblclick rename (native prompt),
+  right-click delete (native confirm, disabled for the last sheet), HTML5 drag reorder,
+  `+` add. The client-local filter resets on sheet switch.
+- **Sort** (`sheetSortFilter.ts`): A→Z / Z→A toolbar buttons sort the selected range by
+  the focused column as a batch of `setCell` ops; moved formulas shift row refs via the
+  fill heuristic (`adjustFormula`). Numbers sort numerically, empties always last.
+- **Filter**: toolbar dropdown of the focused column's distinct values; hides
+  non-matching rows client-side (blank rows stay visible). Not collaborative in v1 —
+  collaborative filter is the upgrade path.
+
+## Testing
+
+- Go: `lib/sheet/structural_test.go` (apply/validate/transform/convergence/snapshot,
+  dim shifting). `TestApplyUnknownSheet` now asserts the no-op semantics.
+- TS: `structural.test.ts` (op mirror), `sheetSortFilter.test.ts` (sort batch, formula
+  shift, distinct/hide predicates).
+- E2E: `playwright/specs/sheet_structural.spec.ts` — tabs add/switch/rename with
+  per-sheet data isolation, column resize persisting across reload, sticky frozen row,
+  A→Z sort, filter hide/clear. Ran live 5/5 green (plus the 10 existing sheet specs).
+
+## Known ceilings (deliberate)
+
+- Filter: one active column filter, client-local.
+- Freeze: first row / first col only.
+- No virtualization; 200×52 is the practical grid bound for the DOM view.

--- a/lib/sheet/apply.go
+++ b/lib/sheet/apply.go
@@ -1,6 +1,9 @@
 package sheet
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // Apply mutates the workbook by op. The op is assumed already rebased to the
 // current revision (see reconcile.go). Cell ops are last-writer-wins; the
@@ -9,9 +12,47 @@ func (w *Workbook) Apply(op Op) error {
 	if err := op.Validate(); err != nil {
 		return err
 	}
+
+	// Sheet-list ops manage w.Sheets itself and never need an existing sheet.
+	switch op.Type {
+	case OpAddSheet:
+		if w.SheetByID(op.Sheet) != nil {
+			return nil // concurrent duplicate add: first wins
+		}
+		w.Sheets = slices.Insert(w.Sheets, min(op.Index, len(w.Sheets)), NewSheet(op.Sheet, op.Name))
+		return nil
+	case OpDeleteSheet:
+		if len(w.Sheets) <= 1 {
+			return nil // never delete the last sheet
+		}
+		for i, s := range w.Sheets {
+			if s.Id == op.Sheet {
+				w.Sheets = slices.Delete(w.Sheets, i, i+1)
+				return nil
+			}
+		}
+		return nil
+	case OpRenameSheet:
+		if s := w.SheetByID(op.Sheet); s != nil {
+			s.Name = op.Name
+		}
+		return nil
+	case OpMoveSheet:
+		for i, s := range w.Sheets {
+			if s.Id == op.Sheet {
+				rest := slices.Delete(slices.Clone(w.Sheets), i, i+1)
+				w.Sheets = slices.Insert(rest, min(op.ToIndex, len(rest)), s)
+				return nil
+			}
+		}
+		return nil
+	}
+
 	s := w.SheetByID(op.Sheet)
 	if s == nil {
-		return fmt.Errorf("apply: unknown sheet %q", op.Sheet)
+		// The sheet was deleted by an op ordered earlier; late ops targeting it
+		// converge as no-ops instead of poisoning the ordered-log replay.
+		return nil
 	}
 	switch op.Type {
 	case OpSetCell:
@@ -47,6 +88,15 @@ func (w *Workbook) Apply(op Op) error {
 				delete(s.Cells, ref)
 			}
 		}
+	case OpSetDimension:
+		if op.Axis == "col" {
+			s.ColWidths[op.Index] = op.Size
+		} else {
+			s.RowHeights[op.Index] = op.Size
+		}
+	case OpSetFreeze:
+		s.FrozenRows = op.FrozenRows
+		s.FrozenCols = op.FrozenCols
 	case OpInsertRows:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Row >= op.Index {
@@ -54,6 +104,7 @@ func (w *Workbook) Apply(op Op) error {
 			}
 			return r, true
 		})
+		s.RowHeights = shiftDims(s.RowHeights, op.Index, op.Count)
 	case OpDeleteRows:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Row >= op.Index && r.Row < op.Index+op.Count {
@@ -64,6 +115,7 @@ func (w *Workbook) Apply(op Op) error {
 			}
 			return r, true
 		})
+		s.RowHeights = shiftDims(s.RowHeights, op.Index, -op.Count)
 	case OpInsertCols:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Col >= op.Index {
@@ -71,6 +123,7 @@ func (w *Workbook) Apply(op Op) error {
 			}
 			return r, true
 		})
+		s.ColWidths = shiftDims(s.ColWidths, op.Index, op.Count)
 	case OpDeleteCols:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Col >= op.Index && r.Col < op.Index+op.Count {
@@ -81,6 +134,7 @@ func (w *Workbook) Apply(op Op) error {
 			}
 			return r, true
 		})
+		s.ColWidths = shiftDims(s.ColWidths, op.Index, -op.Count)
 	default:
 		return fmt.Errorf("apply: unhandled op type %q", op.Type)
 	}

--- a/lib/sheet/apply_test.go
+++ b/lib/sheet/apply_test.go
@@ -82,9 +82,11 @@ func TestApplyInsertColsShiftsCells(t *testing.T) {
 }
 
 func TestApplyUnknownSheet(t *testing.T) {
+	// No-op, not an error: after a deleteSheet, late ops targeting the gone
+	// sheet must not poison the ordered-log replay (M4 convergence rule).
 	w := mkWB(t)
-	if err := w.Apply(Op{Type: OpSetCell, Sheet: "nope", Row: 0, Col: 0, Raw: ptr("x")}); err == nil {
-		t.Fatal("apply to unknown sheet must error")
+	if err := w.Apply(Op{Type: OpSetCell, Sheet: "nope", Row: 0, Col: 0, Raw: ptr("x")}); err != nil {
+		t.Fatalf("apply to unknown sheet must be a silent no-op, got %v", err)
 	}
 }
 

--- a/lib/sheet/op.go
+++ b/lib/sheet/op.go
@@ -15,6 +15,14 @@ const (
 	OpDeleteRows OpType = "deleteRows"
 	OpInsertCols OpType = "insertCols"
 	OpDeleteCols OpType = "deleteCols"
+	// Sheet-list ops: Op.Sheet names the target sheet id.
+	OpAddSheet    OpType = "addSheet"
+	OpRenameSheet OpType = "renameSheet"
+	OpDeleteSheet OpType = "deleteSheet"
+	OpMoveSheet   OpType = "moveSheet"
+	// Grid metadata ops.
+	OpSetDimension OpType = "setDimension"
+	OpSetFreeze    OpType = "setFreeze"
 )
 
 // Op is one cell-based operation. BaseRev is the workbook revision the client
@@ -42,9 +50,22 @@ type Op struct {
 	// When present, Apply interns them and sets the cell's StyleId to the result.
 	Props map[string]string `json:"props,omitempty"`
 
-	// Structural ops (insert/delete rows/cols).
+	// Structural ops (insert/delete rows/cols). Index doubles as the insertion
+	// position for addSheet.
 	Index int `json:"index,omitempty"`
 	Count int `json:"count,omitempty"`
+
+	// Sheet-list ops.
+	Name    string `json:"name,omitempty"`    // addSheet, renameSheet
+	ToIndex int    `json:"toIndex,omitempty"` // moveSheet
+
+	// setDimension.
+	Axis string `json:"axis,omitempty"` // "col" or "row"
+	Size int    `json:"size,omitempty"` // px
+
+	// setFreeze. 0 or 1 each (freeze first row / first col only for now).
+	FrozenRows int `json:"frozenRows,omitempty"`
+	FrozenCols int `json:"frozenCols,omitempty"`
 }
 
 func (o Op) isStructural() bool {
@@ -91,6 +112,36 @@ func (o Op) Validate() error {
 		}
 		if o.Count <= 0 {
 			return fmt.Errorf("%s count must be > 0", o.Type)
+		}
+	case OpAddSheet, OpRenameSheet:
+		if o.Name == "" {
+			return fmt.Errorf("%s needs a name", o.Type)
+		}
+		if len(o.Name) > 128 {
+			return fmt.Errorf("%s name too long", o.Type)
+		}
+		if o.Index < 0 {
+			return fmt.Errorf("%s negative index", o.Type)
+		}
+	case OpDeleteSheet:
+		// Last-sheet protection is stateful and enforced in Apply.
+	case OpMoveSheet:
+		if o.ToIndex < 0 {
+			return fmt.Errorf("moveSheet negative toIndex")
+		}
+	case OpSetDimension:
+		if o.Axis != "col" && o.Axis != "row" {
+			return fmt.Errorf("setDimension axis must be col or row")
+		}
+		if o.Index < 0 {
+			return fmt.Errorf("setDimension negative index")
+		}
+		if o.Size <= 0 || o.Size > 4096 {
+			return fmt.Errorf("setDimension size out of range")
+		}
+	case OpSetFreeze:
+		if o.FrozenRows < 0 || o.FrozenRows > 1 || o.FrozenCols < 0 || o.FrozenCols > 1 {
+			return fmt.Errorf("setFreeze supports only 0 or 1 frozen rows/cols")
 		}
 	default:
 		return fmt.Errorf("unknown op type %q", o.Type)

--- a/lib/sheet/sheet.go
+++ b/lib/sheet/sheet.go
@@ -1,14 +1,22 @@
 package sheet
 
+import "maps"
+
 // Sheet is a single tab: sparse cells plus structural metadata.
 type Sheet struct {
 	Id    string           `json:"id"`
 	Name  string           `json:"name"`
 	Cells map[CellRef]Cell `json:"-"` // sparse; JSON handled by the snapshot/persistence layer
+	// Sparse per-index pixel overrides; unset = view default.
+	ColWidths  map[int]int `json:"-"`
+	RowHeights map[int]int `json:"-"`
+	// 0 or 1 each: freeze the first row / first col (position: sticky in the view).
+	FrozenRows int `json:"-"`
+	FrozenCols int `json:"-"`
 }
 
 func NewSheet(id, name string) *Sheet {
-	return &Sheet{Id: id, Name: name, Cells: map[CellRef]Cell{}}
+	return &Sheet{Id: id, Name: name, Cells: map[CellRef]Cell{}, ColWidths: map[int]int{}, RowHeights: map[int]int{}}
 }
 
 // SetCell stores a cell, dropping it from storage if empty (keeps it sparse).
@@ -26,11 +34,30 @@ func (s *Sheet) GetCell(ref CellRef) Cell {
 }
 
 func (s *Sheet) clone() *Sheet {
-	cp := &Sheet{Id: s.Id, Name: s.Name, Cells: make(map[CellRef]Cell, len(s.Cells))}
-	for k, v := range s.Cells {
-		cp.Cells[k] = v
+	cp := &Sheet{
+		Id: s.Id, Name: s.Name, Cells: make(map[CellRef]Cell, len(s.Cells)),
+		ColWidths: maps.Clone(s.ColWidths), RowHeights: maps.Clone(s.RowHeights),
+		FrozenRows: s.FrozenRows, FrozenCols: s.FrozenCols,
 	}
+	maps.Copy(cp.Cells, s.Cells)
 	return cp
+}
+
+// shiftDims rebuilds a sparse dimension map after an insert/delete at index.
+// delta > 0 inserts (indices at/after move up); delta < 0 deletes a band of
+// -delta indices (entries inside the band are dropped).
+func shiftDims(m map[int]int, index, delta int) map[int]int {
+	if len(m) == 0 {
+		return m
+	}
+	next := make(map[int]int, len(m))
+	for i, v := range m {
+		if delta < 0 && i >= index && i < index-delta {
+			continue // deleted band
+		}
+		next[shiftCoord(i, index, delta)] = v
+	}
+	return next
 }
 
 // remap rebuilds the sparse cell map by transforming each ref. The fn returns

--- a/lib/sheet/snapshot.go
+++ b/lib/sheet/snapshot.go
@@ -1,6 +1,9 @@
 package sheet
 
-import "sort"
+import (
+	"maps"
+	"sort"
+)
 
 // CellSnapshot is the serializable form of one populated cell (map keys can't
 // be JSON-encoded, so cells become a flat slice).
@@ -17,6 +20,11 @@ type SheetSnapshot struct {
 	Id    string         `json:"id"`
 	Name  string         `json:"name"`
 	Cells []CellSnapshot `json:"cells"`
+	// Sparse dimension overrides; JSON object keys are stringified indices.
+	ColWidths  map[int]int `json:"colWidths,omitempty"`
+	RowHeights map[int]int `json:"rowHeights,omitempty"`
+	FrozenRows int         `json:"frozenRows,omitempty"`
+	FrozenCols int         `json:"frozenCols,omitempty"`
 }
 
 // WorkbookSnapshot is the JSON-serializable form of a Workbook for persistence.
@@ -40,7 +48,14 @@ func (w *Workbook) Snapshot() WorkbookSnapshot {
 			}
 			return cells[a].Col < cells[b].Col
 		})
-		out.Sheets[i] = SheetSnapshot{Id: s.Id, Name: s.Name, Cells: cells}
+		ss := SheetSnapshot{Id: s.Id, Name: s.Name, Cells: cells, FrozenRows: s.FrozenRows, FrozenCols: s.FrozenCols}
+		if len(s.ColWidths) > 0 {
+			ss.ColWidths = s.ColWidths
+		}
+		if len(s.RowHeights) > 0 {
+			ss.RowHeights = s.RowHeights
+		}
+		out.Sheets[i] = ss
 	}
 	return out
 }
@@ -66,6 +81,9 @@ func WorkbookFromSnapshot(snap WorkbookSnapshot) *Workbook {
 		for _, c := range ss.Cells {
 			sh.Cells[CellRef{c.Row, c.Col}] = Cell{Raw: c.Raw, Value: c.Value, ValueType: c.ValueType, StyleId: c.StyleId}
 		}
+		maps.Copy(sh.ColWidths, ss.ColWidths)
+		maps.Copy(sh.RowHeights, ss.RowHeights)
+		sh.FrozenRows, sh.FrozenCols = ss.FrozenRows, ss.FrozenCols
 		w.Sheets[i] = sh
 	}
 	return w

--- a/lib/sheet/snapshot.go
+++ b/lib/sheet/snapshot.go
@@ -49,11 +49,13 @@ func (w *Workbook) Snapshot() WorkbookSnapshot {
 			return cells[a].Col < cells[b].Col
 		})
 		ss := SheetSnapshot{Id: s.Id, Name: s.Name, Cells: cells, FrozenRows: s.FrozenRows, FrozenCols: s.FrozenCols}
+		// Clone: snapshots are consumed after the document lock is released
+		// (export), so aliasing the live maps would race with Apply().
 		if len(s.ColWidths) > 0 {
-			ss.ColWidths = s.ColWidths
+			ss.ColWidths = maps.Clone(s.ColWidths)
 		}
 		if len(s.RowHeights) > 0 {
-			ss.RowHeights = s.RowHeights
+			ss.RowHeights = maps.Clone(s.RowHeights)
 		}
 		out.Sheets[i] = ss
 	}

--- a/lib/sheet/structural_test.go
+++ b/lib/sheet/structural_test.go
@@ -1,0 +1,195 @@
+package sheet
+
+import "testing"
+
+func wb2() *Workbook {
+	w := NewWorkbook()
+	w.AddSheet("s1", "Sheet1")
+	w.AddSheet("s2", "Sheet2")
+	return w
+}
+
+func sheetIds(w *Workbook) []string {
+	ids := make([]string, len(w.Sheets))
+	for i, s := range w.Sheets {
+		ids[i] = s.Id
+	}
+	return ids
+}
+
+func TestSheetListOps(t *testing.T) {
+	w := wb2()
+	if err := w.Apply(Op{Type: OpAddSheet, Sheet: "s3", Name: "Drei", Index: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if got := sheetIds(w); got[0] != "s1" || got[1] != "s3" || got[2] != "s2" {
+		t.Fatalf("addSheet at index 1: got %v", got)
+	}
+	// duplicate add converges as no-op
+	if err := w.Apply(Op{Type: OpAddSheet, Sheet: "s3", Name: "Nochmal", Index: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if len(w.Sheets) != 3 || w.SheetByID("s3").Name != "Drei" {
+		t.Fatalf("duplicate addSheet must be a no-op: %v", sheetIds(w))
+	}
+	if err := w.Apply(Op{Type: OpRenameSheet, Sheet: "s3", Name: "Umbenannt"}); err != nil {
+		t.Fatal(err)
+	}
+	if w.SheetByID("s3").Name != "Umbenannt" {
+		t.Fatal("renameSheet did not rename")
+	}
+	if err := w.Apply(Op{Type: OpMoveSheet, Sheet: "s3", ToIndex: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if got := sheetIds(w); got[2] != "s3" {
+		t.Fatalf("moveSheet to end: got %v", got)
+	}
+	if err := w.Apply(Op{Type: OpDeleteSheet, Sheet: "s3"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(w.Sheets) != 2 || w.SheetByID("s3") != nil {
+		t.Fatal("deleteSheet did not delete")
+	}
+}
+
+func TestDeleteLastSheetIsNoop(t *testing.T) {
+	w := NewWorkbook()
+	w.AddSheet("s1", "Sheet1")
+	if err := w.Apply(Op{Type: OpDeleteSheet, Sheet: "s1"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(w.Sheets) != 1 {
+		t.Fatal("the last sheet must never be deleted")
+	}
+}
+
+func TestOpsOnDeletedSheetAreNoops(t *testing.T) {
+	w := wb2()
+	raw := "x"
+	if err := w.Apply(Op{Type: OpDeleteSheet, Sheet: "s2"}); err != nil {
+		t.Fatal(err)
+	}
+	// A late op composed against the pre-delete state must not error.
+	if err := w.Apply(Op{Type: OpSetCell, Sheet: "s2", Row: 0, Col: 0, Raw: &raw}); err != nil {
+		t.Fatalf("op on deleted sheet must be a no-op, got %v", err)
+	}
+}
+
+func TestSetDimensionAndFreeze(t *testing.T) {
+	w := wb2()
+	if err := w.Apply(Op{Type: OpSetDimension, Sheet: "s1", Axis: "col", Index: 2, Size: 140}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Apply(Op{Type: OpSetDimension, Sheet: "s1", Axis: "row", Index: 5, Size: 40}); err != nil {
+		t.Fatal(err)
+	}
+	s := w.SheetByID("s1")
+	if s.ColWidths[2] != 140 || s.RowHeights[5] != 40 {
+		t.Fatalf("dims not stored: %v %v", s.ColWidths, s.RowHeights)
+	}
+	if err := w.Apply(Op{Type: OpSetFreeze, Sheet: "s1", FrozenRows: 1, FrozenCols: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if s.FrozenRows != 1 || s.FrozenCols != 1 {
+		t.Fatal("freeze not stored")
+	}
+}
+
+func TestDimsShiftUnderStructuralOps(t *testing.T) {
+	w := wb2()
+	must := func(op Op) {
+		t.Helper()
+		if err := w.Apply(op); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(Op{Type: OpSetDimension, Sheet: "s1", Axis: "col", Index: 3, Size: 120})
+	must(Op{Type: OpSetDimension, Sheet: "s1", Axis: "row", Index: 4, Size: 44})
+
+	must(Op{Type: OpInsertCols, Sheet: "s1", Index: 0, Count: 2})
+	if w.SheetByID("s1").ColWidths[5] != 120 {
+		t.Fatalf("col width must shift right on insert: %v", w.SheetByID("s1").ColWidths)
+	}
+	must(Op{Type: OpDeleteCols, Sheet: "s1", Index: 0, Count: 2})
+	if w.SheetByID("s1").ColWidths[3] != 120 {
+		t.Fatalf("col width must shift back on delete: %v", w.SheetByID("s1").ColWidths)
+	}
+	// deleting the band containing the override drops it
+	must(Op{Type: OpDeleteRows, Sheet: "s1", Index: 4, Count: 1})
+	if len(w.SheetByID("s1").RowHeights) != 0 {
+		t.Fatalf("row height inside deleted band must drop: %v", w.SheetByID("s1").RowHeights)
+	}
+}
+
+func TestSnapshotRoundTripDimsAndSheets(t *testing.T) {
+	w := wb2()
+	w.SheetByID("s1").ColWidths[1] = 99
+	w.SheetByID("s1").RowHeights[2] = 33
+	w.SheetByID("s1").FrozenRows = 1
+	got := WorkbookFromSnapshot(w.Snapshot())
+	s := got.SheetByID("s1")
+	if s.ColWidths[1] != 99 || s.RowHeights[2] != 33 || s.FrozenRows != 1 {
+		t.Fatalf("snapshot round-trip lost dims/freeze: %+v", s)
+	}
+	if len(got.Sheets) != 2 || got.Sheets[1].Id != "s2" {
+		t.Fatal("snapshot round-trip lost sheet order")
+	}
+}
+
+func TestTransformSetDimensionUnderInsert(t *testing.T) {
+	in := Op{Type: OpSetDimension, Sheet: "s1", Axis: "col", Index: 3, Size: 100}
+	out := Transform(in, Op{Type: OpInsertCols, Sheet: "s1", Index: 1, Count: 2})
+	if out.Index != 5 {
+		t.Fatalf("setDimension col index must shift: got %d", out.Index)
+	}
+	// row-axis dimension is untouched by column inserts
+	in.Axis = "row"
+	out = Transform(in, Op{Type: OpInsertCols, Sheet: "s1", Index: 1, Count: 2})
+	if out.Index != 3 {
+		t.Fatalf("row dimension must not shift under col insert: got %d", out.Index)
+	}
+}
+
+func TestStructuralValidate(t *testing.T) {
+	bad := []Op{
+		{Type: OpAddSheet, Sheet: "sX"},                                       // missing name
+		{Type: OpRenameSheet, Sheet: "s1"},                                    // missing name
+		{Type: OpMoveSheet, Sheet: "s1", ToIndex: -1},                         // negative index
+		{Type: OpSetDimension, Sheet: "s1", Axis: "diag", Index: 0, Size: 10}, // bad axis
+		{Type: OpSetDimension, Sheet: "s1", Axis: "col", Index: 0, Size: 0},   // zero size
+		{Type: OpSetDimension, Sheet: "s1", Axis: "col", Index: 0, Size: 1e6}, // huge size
+		{Type: OpSetFreeze, Sheet: "s1", FrozenRows: 2},                       // only 0/1
+	}
+	for _, op := range bad {
+		if op.Validate() == nil {
+			t.Fatalf("op %+v must be invalid", op)
+		}
+	}
+}
+
+func TestConvergenceConcurrentSheetOps(t *testing.T) {
+	// Two clients: A deletes s2 while B types into s2. Both orders converge.
+	raw := "late"
+	a := Op{Type: OpDeleteSheet, Sheet: "s2"}
+	b := Op{Type: OpSetCell, Sheet: "s2", Row: 0, Col: 0, Raw: &raw}
+
+	w1 := wb2()
+	if err := w1.Apply(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := w1.Apply(Transform(b, a)); err != nil {
+		t.Fatal(err)
+	}
+
+	w2 := wb2()
+	if err := w2.Apply(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Apply(Transform(a, b)); err != nil {
+		t.Fatal(err)
+	}
+
+	if w1.SheetByID("s2") != nil || w2.SheetByID("s2") != nil {
+		t.Fatal("delete must win in both orders")
+	}
+}

--- a/lib/sheet/transform.go
+++ b/lib/sheet/transform.go
@@ -31,6 +31,9 @@ func shiftRows(in Op, index, delta int) Op {
 	if in.Type == OpInsertRows || in.Type == OpDeleteRows {
 		in.Index = shiftCoord(in.Index, index, delta)
 	}
+	if in.Type == OpSetDimension && in.Axis == "row" {
+		in.Index = shiftCoord(in.Index, index, delta)
+	}
 	return in
 }
 
@@ -40,6 +43,9 @@ func shiftCols(in Op, index, delta int) Op {
 		in.EndCol = shiftCoord(in.EndCol, index, delta)
 	}
 	if in.Type == OpInsertCols || in.Type == OpDeleteCols {
+		in.Index = shiftCoord(in.Index, index, delta)
+	}
+	if in.Type == OpSetDimension && in.Axis == "col" {
 		in.Index = shiftCoord(in.Index, index, delta)
 	}
 	return in

--- a/playwright/specs/sheet_structural.spec.ts
+++ b/playwright/specs/sheet_structural.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const cell = (page: Page, r: number, c: number) =>
+  page.locator(`.sheet-grid tbody tr:nth-child(${r + 1}) td:nth-child(${c + 2})`);
+
+async function openSheet(page: Page, padId: string): Promise<void> {
+  await page.goto(`/s/${padId}`);
+  await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+}
+
+async function typeInto(page: Page, r: number, c: number, text: string): Promise<void> {
+  await cell(page, r, c).click();
+  await page.keyboard.type(text);
+  await page.keyboard.press('Enter');
+}
+
+test.describe('Sheet M4 structural', () => {
+  test('tabs: add, switch, rename; data stays per sheet', async ({ page }) => {
+    await openSheet(page, `m4-tabs-${Date.now()}`);
+    await typeInto(page, 0, 0, 'erstes');
+
+    await page.locator('.sheet-tab-add').click();
+    await expect(page.locator('.sheet-tabs button.sheet-tab-active')).toHaveText('Sheet2');
+    // The new sheet is empty; the first sheet's value must not bleed through.
+    await expect(cell(page, 0, 0)).toHaveText('');
+
+    await typeInto(page, 0, 0, 'zweites');
+    await page.locator('.sheet-tabs button', { hasText: 'Sheet1' }).click();
+    await expect(cell(page, 0, 0)).toHaveText('erstes');
+
+    // rename via dblclick prompt
+    page.once('dialog', (d) => d.accept('Daten'));
+    await page.locator('.sheet-tabs button', { hasText: 'Sheet2' }).dblclick();
+    await expect(page.locator('.sheet-tabs button', { hasText: 'Daten' })).toHaveCount(1);
+  });
+
+  test('column resize emits setDimension and persists across reload', async ({ page }) => {
+    const pad = `m4-resize-${Date.now()}`;
+    await openSheet(page, pad);
+    const colB = page.locator('.sheet-grid thead th').nth(2); // corner + A + B
+    const before = (await colB.boundingBox())!.width;
+    const grip = colB.locator('.sheet-resizer-col');
+    const gb = (await grip.boundingBox())!;
+    await page.mouse.move(gb.x + gb.width / 2, gb.y + gb.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(gb.x + gb.width / 2 + 60, gb.y + gb.height / 2);
+    await page.mouse.up();
+    await page.waitForTimeout(500);
+    const after = (await colB.boundingBox())!.width;
+    expect(after).toBeGreaterThan(before + 40);
+
+    await page.reload();
+    await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+    const persisted = (await page.locator('.sheet-grid thead th').nth(2).boundingBox())!.width;
+    expect(persisted).toBeGreaterThan(before + 40);
+  });
+
+  test('freeze first row makes it sticky', async ({ page }) => {
+    await openSheet(page, `m4-freeze-${Date.now()}`);
+    await typeInto(page, 0, 0, 'kopf');
+    await page.locator('.sheet-toolbar button', { hasText: '❄R' }).click();
+    await page.waitForTimeout(400);
+    await expect(page.locator('.sheet-grid')).toHaveClass(/sheet-frozen-r/);
+    const sticky = await cell(page, 0, 0).evaluate((el) => getComputedStyle(el).position);
+    expect(sticky).toBe('sticky');
+  });
+
+  test('sort A→Z reorders the selected range by the focused column', async ({ page }) => {
+    await openSheet(page, `m4-sort-${Date.now()}`);
+    await typeInto(page, 0, 0, '3');
+    await typeInto(page, 1, 0, '1');
+    await typeInto(page, 2, 0, '2');
+    // select A1:A3 by dragging
+    await cell(page, 0, 0).hover();
+    await page.mouse.down();
+    await cell(page, 2, 0).hover();
+    await page.mouse.up();
+    await page.locator('.sheet-toolbar button', { hasText: 'A→Z' }).click();
+    await page.waitForTimeout(600);
+    await expect(cell(page, 0, 0)).toHaveText('1');
+    await expect(cell(page, 1, 0)).toHaveText('2');
+    await expect(cell(page, 2, 0)).toHaveText('3');
+  });
+
+  test('filter hides non-matching rows client-side', async ({ page }) => {
+    await openSheet(page, `m4-filter-${Date.now()}`);
+    await typeInto(page, 0, 0, 'x');
+    await typeInto(page, 1, 0, 'y');
+    await typeInto(page, 2, 0, 'x');
+    await cell(page, 0, 0).click();
+    // The dropdown fills its options lazily on open; selectOption() bypasses
+    // the native open, so trigger the repopulation explicitly first.
+    await page.locator('.sheet-toolbar select').last().dispatchEvent('mousedown');
+    await page.locator('.sheet-toolbar select').last().selectOption('x');
+    await expect(page.locator('.sheet-grid tbody tr').nth(1)).toBeHidden();
+    await expect(page.locator('.sheet-grid tbody tr').nth(0)).toBeVisible();
+    await expect(page.locator('.sheet-grid tbody tr').nth(2)).toBeVisible();
+    // clear
+    await page.locator('.sheet-toolbar select').last().selectOption('');
+    await expect(page.locator('.sheet-grid tbody tr').nth(1)).toBeVisible();
+  });
+});

--- a/ui/src/js/sheet/op.ts
+++ b/ui/src/js/sheet/op.ts
@@ -9,7 +9,13 @@ export type OpType =
   | 'insertRows'
   | 'deleteRows'
   | 'insertCols'
-  | 'deleteCols';
+  | 'deleteCols'
+  | 'addSheet'
+  | 'renameSheet'
+  | 'deleteSheet'
+  | 'moveSheet'
+  | 'setDimension'
+  | 'setFreeze';
 
 export interface Op {
   type: OpType;
@@ -28,9 +34,18 @@ export interface Op {
   styleId?: number;
   // setCell / setStyle style properties, interned into the workbook style pool.
   props?: Record<string, string>;
-  // structural ops
+  // structural ops; index doubles as the insertion position for addSheet
   index?: number;
   count?: number;
+  // sheet-list ops
+  name?: string; // addSheet, renameSheet
+  toIndex?: number; // moveSheet
+  // setDimension
+  axis?: 'col' | 'row';
+  size?: number; // px
+  // setFreeze (0 or 1 each)
+  frozenRows?: number;
+  frozenCols?: number;
 }
 
 // serializeOp produces the JSON the Go server unmarshals into sheet.Op.

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -7,6 +7,8 @@ import { SheetPresence, effectiveCells, type PresenceFrame } from './sheetPresen
 import { rangeToTSV, parseTSV, pasteOps, fillOps } from './sheetClipboard';
 import { normalize, selCells, selIsSingle, type Selection } from './sheetSelection';
 import { createToolbar } from './sheetToolbar';
+import { createSheetTabs } from './sheetTabs';
+import { sortRangeOps, distinctValues, hiddenRowsForFilter } from './sheetSortFilter';
 import { createFormulaBar, type FormulaBarHandle } from './sheetFormulaBar';
 import { rangeRefA1 } from './a1';
 import { mergeProps } from './styleCss';
@@ -39,6 +41,11 @@ export function startSheetEditor(root: HTMLElement): void {
   const engine = new FormulaEngine();
   let selection: Selection = { anchor: { row: 0, col: 0 }, focus: { row: 0, col: 0 } };
   let readOnly = false;
+  const GRID_ROWS = 200;
+  const GRID_COLS = 52;
+  // Client-local filter state (per active sheet, reset on switch — not collaborative).
+  let hiddenRows = new Set<number>();
+  let tabs: { el: HTMLElement; refresh: () => void } | null = null;
 
   const transport = {
     send: (op: Op) =>
@@ -153,6 +160,7 @@ export function startSheetEditor(root: HTMLElement): void {
       );
     }
     view?.render();
+    tabs?.refresh();
     if (formulaBar) {
       const { r0, c0, r1, c1 } = normalize(selection);
       formulaBar.setActive(rangeRefA1(r0, c0, r1, c1), rawValue(selection.focus.row, selection.focus.col));
@@ -178,6 +186,29 @@ export function startSheetEditor(root: HTMLElement): void {
       focusCell: () => selection.focus,
       applyToSelection: applyStyleToSelection,
       readOnly: data.readonly,
+      sortSelection: (asc) => {
+        if (readOnly || !collab || selIsSingle(selection)) return;
+        blurActiveCell();
+        for (const op of sortRangeOps(selection, selection.focus.col, asc, activeSheetId, collab.rev, rawValue)) {
+          collab.applyLocal(op);
+        }
+      },
+      toggleFreeze: (kind) => {
+        if (readOnly || !collab) return;
+        const s = collab.display.sheetById(activeSheetId);
+        const rows = kind === 'row' ? ((s?.frozenRows ?? 0) > 0 ? 0 : 1) : (s?.frozenRows ?? 0);
+        const cols = kind === 'col' ? ((s?.frozenCols ?? 0) > 0 ? 0 : 1) : (s?.frozenCols ?? 0);
+        collab.applyLocal({ type: 'setFreeze', sheet: activeSheetId, baseRev: collab.rev, frozenRows: rows, frozenCols: cols });
+      },
+      frozenState: () => {
+        const s = collab?.display.sheetById(activeSheetId);
+        return { rows: s?.frozenRows ?? 0, cols: s?.frozenCols ?? 0 };
+      },
+      filterValues: () => distinctValues(selection.focus.col, GRID_ROWS, rawValue),
+      applyFilter: (value) => {
+        hiddenRows = value === null ? new Set() : hiddenRowsForFilter(selection.focus.col, value, GRID_ROWS, rawValue);
+        view?.render();
+      },
     });
     formulaBar = createFormulaBar({
       readOnly: data.readonly,
@@ -193,13 +224,58 @@ export function startSheetEditor(root: HTMLElement): void {
     root.appendChild(formulaBar.el);
     root.appendChild(gridHost);
 
+    const setActiveSheet = (id: string): void => {
+      if (id === activeSheetId) return;
+      activeSheetId = id;
+      hiddenRows = new Set(); // the filter is per-sheet and client-local
+      onChange();
+    };
+    tabs = createSheetTabs({
+      sheets: () => (collab ? collab.display.sheets.map((s) => ({ id: s.id, name: s.name })) : []),
+      activeId: () => activeSheetId,
+      readOnly: data.readonly,
+      onSwitch: setActiveSheet,
+      onAdd: () => {
+        if (!collab) return;
+        const id = `s-${Math.random().toString(36).slice(2, 10)}`;
+        collab.applyLocal({
+          type: 'addSheet', sheet: id, baseRev: collab.rev,
+          name: `Sheet${collab.display.sheets.length + 1}`, index: collab.display.sheets.length,
+        });
+        setActiveSheet(id);
+      },
+      onRename: (id, name) => {
+        collab?.applyLocal({ type: 'renameSheet', sheet: id, baseRev: collab.rev, name });
+      },
+      onDelete: (id) => {
+        if (!collab) return;
+        collab.applyLocal({ type: 'deleteSheet', sheet: id, baseRev: collab.rev });
+        if (id === activeSheetId) setActiveSheet(collab.display.sheets[0]?.id ?? 's1');
+      },
+      onMove: (id, toIndex) => {
+        collab?.applyLocal({ type: 'moveSheet', sheet: id, baseRev: collab.rev, toIndex });
+      },
+    });
+    root.appendChild(tabs.el);
+
     view = new DomSheetView(gridHost, {
-      rows: 50,
-      cols: 20,
+      rows: GRID_ROWS,
+      cols: GRID_COLS,
       rawValue,
       displayValue,
       readOnly: data.readonly,
       styleOf: (r, c) => propsOf(r, c),
+      colWidth: (c) => collab?.display.sheetById(activeSheetId)?.colWidths.get(c),
+      rowHeight: (r) => collab?.display.sheetById(activeSheetId)?.rowHeights.get(r),
+      frozen: () => {
+        const s = collab?.display.sheetById(activeSheetId);
+        return { rows: s?.frozenRows ?? 0, cols: s?.frozenCols ?? 0 };
+      },
+      onResize: (axis, index, size) => {
+        if (readOnly || !collab) return;
+        collab.applyLocal({ type: 'setDimension', sheet: activeSheetId, baseRev: collab.rev, axis, index, size });
+      },
+      rowHidden: (r) => hiddenRows.has(r),
       // ponytail: second engine.getValue per formula cell per render (displayValue
       // already does one). Cheap: HyperFormula caches, and the raw.startsWith('=')
       // gate skips non-formula cells. Fold into displayValue if the grid grows.

--- a/ui/src/js/sheet/sheetSortFilter.test.ts
+++ b/ui/src/js/sheet/sheetSortFilter.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { sortRangeOps, distinctValues, hiddenRowsForFilter, compareVals } from './sheetSortFilter';
+import type { Selection } from './sheetSelection';
+
+const sel = (r0: number, c0: number, r1: number, c1: number): Selection => ({
+  anchor: { row: r0, col: c0 },
+  focus: { row: r1, col: c1 },
+});
+
+const gridRaw =
+  (grid: string[][]) =>
+  (r: number, c: number): string =>
+    grid[r]?.[c] ?? '';
+
+describe('compareVals', () => {
+  it('numbers numerically, strings lexically, empty last', () => {
+    expect(compareVals('2', '10', true)).toBeLessThan(0);
+    expect(compareVals('b', 'a', true)).toBeGreaterThan(0);
+    expect(compareVals('', 'a', true)).toBeGreaterThan(0); // empty last even asc
+    expect(compareVals('', 'a', false)).toBeGreaterThan(0); // and desc
+  });
+});
+
+describe('sortRangeOps', () => {
+  it('sorts rows by the key column and moves whole rows', () => {
+    const grid = [
+      ['3', 'c'],
+      ['1', 'a'],
+      ['2', 'b'],
+    ];
+    const ops = sortRangeOps(sel(0, 0, 2, 1), 0, true, 's1', 0, gridRaw(grid));
+    // row1 (1,a) -> row0; row2 (2,b) -> row1; row0 (3,c) -> row2
+    const at = (r: number, c: number) => ops.find((o) => o.row === r && o.col === c)?.raw;
+    expect(at(0, 0)).toBe('1');
+    expect(at(0, 1)).toBe('a');
+    expect(at(2, 0)).toBe('3');
+    expect(at(2, 1)).toBe('c');
+  });
+
+  it('adjusts moved formula row refs like fill does', () => {
+    const grid = [
+      ['2', '=A1*2'],
+      ['1', '=A2*2'],
+    ];
+    const ops = sortRangeOps(sel(0, 0, 1, 1), 0, true, 's1', 0, gridRaw(grid));
+    const at = (r: number, c: number) => ops.find((o) => o.row === r && o.col === c)?.raw;
+    expect(at(0, 1)).toBe('=A1*2'); // was =A2*2 on row 1, moved up one row
+    expect(at(1, 1)).toBe('=A2*2');
+  });
+
+  it('emits nothing when already sorted', () => {
+    const grid = [
+      ['1', 'a'],
+      ['2', 'b'],
+    ];
+    expect(sortRangeOps(sel(0, 0, 1, 1), 0, true, 's1', 0, gridRaw(grid))).toEqual([]);
+  });
+});
+
+describe('filter helpers', () => {
+  const grid = [['x'], ['y'], ['x'], [''], ['z']];
+  it('distinctValues sorted + deduped, blanks excluded', () => {
+    expect(distinctValues(0, 5, gridRaw(grid))).toEqual(['x', 'y', 'z']);
+  });
+  it('hiddenRowsForFilter hides non-matching, keeps blanks visible', () => {
+    const hidden = hiddenRowsForFilter(0, 'x', 5, gridRaw(grid));
+    expect([...hidden].sort()).toEqual([1, 4]);
+  });
+});

--- a/ui/src/js/sheet/sheetSortFilter.ts
+++ b/ui/src/js/sheet/sheetSortFilter.ts
@@ -1,0 +1,90 @@
+// Pure sort + filter helpers. Sort is collaborative (a batch of setCell ops:
+// data moves, the server only sees cell ops). Filter is client-local row
+// hiding — no ops, not shared (collaborative filter is the upgrade path).
+
+import type { Op } from './op';
+import type { Selection } from './sheetSelection';
+import { normalize } from './sheetSelection';
+import { adjustFormula } from './sheetClipboard';
+
+// compareVals: numbers numerically, everything else lexically; empty always
+// sorts last regardless of direction (Excel behavior).
+export function compareVals(a: string, b: string, asc: boolean): number {
+  if (a === '' && b === '') return 0;
+  if (a === '') return 1;
+  if (b === '') return -1;
+  const na = Number(a);
+  const nb = Number(b);
+  const base =
+    !Number.isNaN(na) && !Number.isNaN(nb) ? na - nb : a.localeCompare(b, undefined, { numeric: true });
+  return asc ? base : -base;
+}
+
+// sortRangeOps reorders the rows of the selected range by the given column and
+// emits one setCell per cell of the range (moved formulas shift row refs like
+// fill does). byCol must lie inside the selection.
+export function sortRangeOps(
+  sel: Selection,
+  byCol: number,
+  asc: boolean,
+  sheet: string,
+  baseRev: number,
+  rawAt: (r: number, c: number) => string,
+): Op[] {
+  const { r0, c0, r1, c1 } = normalize(sel);
+  const keyIdx = Math.min(Math.max(byCol, c0), c1) - c0;
+  const rows: string[][] = [];
+  for (let r = r0; r <= r1; r++) {
+    const cells: string[] = [];
+    for (let c = c0; c <= c1; c++) cells.push(rawAt(r, c));
+    rows.push(cells);
+  }
+  const order = rows
+    .map((cells, i) => ({ cells, srcRow: r0 + i }))
+    .sort((a, b) => compareVals(a.cells[keyIdx], b.cells[keyIdx], asc)); // stable
+
+  const ops: Op[] = [];
+  for (let i = 0; i < order.length; i++) {
+    const destRow = r0 + i;
+    const { cells, srcRow } = order[i];
+    if (srcRow === destRow) continue; // row did not move
+    for (let c = c0; c <= c1; c++) {
+      ops.push({
+        type: 'setCell', sheet, baseRev, row: destRow, col: c,
+        raw: adjustFormula(cells[c - c0], destRow - srcRow, 0),
+      });
+    }
+  }
+  return ops;
+}
+
+// distinctValues lists the non-empty values present in a column (sorted),
+// for the filter dropdown.
+export function distinctValues(
+  col: number,
+  rowCount: number,
+  rawAt: (r: number, c: number) => string,
+): string[] {
+  const seen = new Set<string>();
+  for (let r = 0; r < rowCount; r++) {
+    const v = rawAt(r, col);
+    if (v !== '') seen.add(v);
+  }
+  return [...seen].sort((a, b) => compareVals(a, b, true));
+}
+
+// hiddenRowsForFilter: rows whose column value is non-empty and differs from
+// `keep`. Blank rows stay visible (the empty grid must not collapse).
+export function hiddenRowsForFilter(
+  col: number,
+  keep: string,
+  rowCount: number,
+  rawAt: (r: number, c: number) => string,
+): Set<number> {
+  const hidden = new Set<number>();
+  for (let r = 0; r < rowCount; r++) {
+    const v = rawAt(r, col);
+    if (v !== '' && v !== keep) hidden.add(r);
+  }
+  return hidden;
+}

--- a/ui/src/js/sheet/sheetTabs.ts
+++ b/ui/src/js/sheet/sheetTabs.ts
@@ -1,0 +1,77 @@
+// Bottom tabs bar: one tab per sheet. Click switches, double-click renames
+// (native prompt), right-click deletes (native confirm), drag reorders,
+// '+' adds. Pure DOM, no framework — call refresh() after workbook changes.
+
+export interface TabsCallbacks {
+  sheets: () => Array<{ id: string; name: string }>;
+  activeId: () => string;
+  onSwitch: (id: string) => void;
+  onAdd: () => void;
+  onRename: (id: string, name: string) => void;
+  onDelete: (id: string) => void;
+  onMove: (id: string, toIndex: number) => void;
+  readOnly?: boolean;
+}
+
+const STYLE_ID = 'sheet-tabs-style';
+const CSS = `
+.sheet-tabs { display: flex; gap: 2px; align-items: center; padding: 4px 2px; font: 12px/1.4 system-ui, sans-serif; }
+.sheet-tabs button { border: 1px solid #d2d2d2; background: #f2f3f4; color: #485365; padding: 3px 12px; cursor: pointer; border-radius: 0 0 4px 4px; }
+.sheet-tabs button.sheet-tab-active { background: #fff; font-weight: 600; border-top-color: #fff; }
+.sheet-tabs button.sheet-tab-add { padding: 3px 8px; font-weight: 700; }
+`;
+
+export function createSheetTabs(cb: TabsCallbacks): { el: HTMLElement; refresh: () => void } {
+  if (!document.getElementById(STYLE_ID)) {
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  const el = document.createElement('div');
+  el.className = 'sheet-tabs';
+
+  const refresh = (): void => {
+    el.innerHTML = '';
+    const sheets = cb.sheets();
+    sheets.forEach((s, i) => {
+      const tab = document.createElement('button');
+      tab.textContent = s.name || s.id;
+      tab.dataset.sheetId = s.id;
+      tab.classList.toggle('sheet-tab-active', s.id === cb.activeId());
+      tab.addEventListener('click', () => cb.onSwitch(s.id));
+      if (!cb.readOnly) {
+        tab.addEventListener('dblclick', () => {
+          const name = prompt('Sheet name', s.name);
+          if (name && name !== s.name) cb.onRename(s.id, name);
+        });
+        tab.addEventListener('contextmenu', (e) => {
+          e.preventDefault();
+          if (sheets.length <= 1) return; // the last sheet cannot be deleted
+          if (confirm(`Delete sheet "${s.name}"?`)) cb.onDelete(s.id);
+        });
+        tab.draggable = true;
+        tab.addEventListener('dragstart', (e) => e.dataTransfer?.setData('text/sheet-id', s.id));
+        tab.addEventListener('dragover', (e) => e.preventDefault());
+        tab.addEventListener('drop', (e) => {
+          e.preventDefault();
+          const dragged = e.dataTransfer?.getData('text/sheet-id');
+          if (dragged && dragged !== s.id) cb.onMove(dragged, i);
+        });
+      }
+      el.appendChild(tab);
+    });
+    if (!cb.readOnly) {
+      const add = document.createElement('button');
+      add.className = 'sheet-tab-add';
+      add.textContent = '+';
+      add.title = 'Add sheet';
+      add.addEventListener('click', () => cb.onAdd());
+      el.appendChild(add);
+    }
+  };
+
+  refresh();
+  return { el, refresh };
+}

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -7,6 +7,13 @@ export interface ToolbarCallbacks {
   focusCell: () => { row: number; col: number };
   applyToSelection: (change: Record<string, string>) => void;
   readOnly: boolean;
+  // M4 structural actions.
+  sortSelection?: (asc: boolean) => void;
+  toggleFreeze?: (kind: 'row' | 'col') => void;
+  frozenState?: () => { rows: number; cols: number };
+  // Filter on the focus column: values() fills the dropdown lazily, apply(null) clears.
+  filterValues?: () => string[];
+  applyFilter?: (value: string | null) => void;
 }
 
 const CSS = `
@@ -79,6 +86,59 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   }
   numFmt.addEventListener('change', () => cb.applyToSelection({ numFmt: numFmt.value }));
   bar.appendChild(numFmt);
+
+  if (cb.sortSelection) {
+    const az = document.createElement('button');
+    az.textContent = 'A→Z';
+    az.title = 'Sort selection ascending by the focused column';
+    az.addEventListener('click', () => cb.sortSelection?.(true));
+    bar.appendChild(az);
+    const za = document.createElement('button');
+    za.textContent = 'Z→A';
+    za.title = 'Sort selection descending by the focused column';
+    za.addEventListener('click', () => cb.sortSelection?.(false));
+    bar.appendChild(za);
+  }
+
+  if (cb.toggleFreeze) {
+    const mk = (label: string, kind: 'row' | 'col', title: string) => {
+      const b = document.createElement('button');
+      b.textContent = label;
+      b.title = title;
+      b.addEventListener('click', () => {
+        cb.toggleFreeze?.(kind);
+        const fz = cb.frozenState?.() ?? { rows: 0, cols: 0 };
+        b.classList.toggle('on', kind === 'row' ? fz.rows > 0 : fz.cols > 0);
+      });
+      const fz = cb.frozenState?.() ?? { rows: 0, cols: 0 };
+      b.classList.toggle('on', kind === 'row' ? fz.rows > 0 : fz.cols > 0);
+      bar.appendChild(b);
+    };
+    mk('❄R', 'row', 'Freeze first row');
+    mk('❄C', 'col', 'Freeze first column');
+  }
+
+  if (cb.filterValues && cb.applyFilter) {
+    const filter = document.createElement('select');
+    filter.title = 'Filter rows by the focused column';
+    const fill = () => {
+      filter.innerHTML = '';
+      const all = document.createElement('option');
+      all.value = '';
+      all.textContent = '▼ Filter: (all)';
+      filter.appendChild(all);
+      for (const v of cb.filterValues?.() ?? []) {
+        const o = document.createElement('option');
+        o.value = v;
+        o.textContent = v;
+        filter.appendChild(o);
+      }
+    };
+    fill();
+    filter.addEventListener('mousedown', fill); // repopulate lazily on open
+    filter.addEventListener('change', () => cb.applyFilter?.(filter.value === '' ? null : filter.value));
+    bar.appendChild(filter);
+  }
 
   return bar;
 }

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -136,6 +136,7 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
     };
     fill();
     filter.addEventListener('mousedown', fill); // repopulate lazily on open
+    filter.addEventListener('focus', fill); // and for keyboard users
     filter.addEventListener('change', () => cb.applyFilter?.(filter.value === '' ? null : filter.value));
     bar.appendChild(filter);
   }

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -32,14 +32,30 @@ export interface SheetViewOptions {
   readOnly?: boolean;
   styleOf?: (row: number, col: number) => Record<string, string>;
   errorOf?: (row: number, col: number) => string | undefined;
+  // M4: sparse dimension overrides (px), freeze state, and resize commits.
+  colWidth?: (col: number) => number | undefined;
+  rowHeight?: (row: number) => number | undefined;
+  frozen?: () => { rows: number; cols: number };
+  onResize?: (axis: 'col' | 'row', index: number, sizePx: number) => void;
+  // Client-local row filter: hidden rows collapse via display:none.
+  rowHidden?: (row: number) => boolean;
 }
 
 const STYLE_ID = 'sheet-grid-style';
+// border-collapse: separate (not collapse) because position: sticky drops
+// collapsed borders while a frozen row/col sticks. Right/bottom-only borders
+// keep the 1px grid look without doubling.
 const CSS = `
-.sheet-grid { border-collapse: collapse; font: 13px/1.4 system-ui, sans-serif; }
-.sheet-grid th, .sheet-grid td { border: 1px solid #d2d2d2; min-width: 80px; height: 22px; padding: 2px 6px; }
-.sheet-grid th { background: #f2f3f4; color: #485365; font-weight: 600; text-align: center; }
-.sheet-grid td { outline: none; position: relative; }
+.sheet-grid { border-collapse: separate; border-spacing: 0; border-top: 1px solid #d2d2d2; border-left: 1px solid #d2d2d2; font: 13px/1.4 system-ui, sans-serif; }
+.sheet-grid th, .sheet-grid td { border-right: 1px solid #d2d2d2; border-bottom: 1px solid #d2d2d2; min-width: 80px; height: 22px; padding: 2px 6px; }
+.sheet-grid th { background: #f2f3f4; color: #485365; font-weight: 600; text-align: center; position: relative; }
+.sheet-grid td { outline: none; position: relative; background: #fff; }
+.sheet-resizer-col { position: absolute; top: 0; right: -3px; width: 6px; height: 100%; cursor: col-resize; z-index: 9; }
+.sheet-resizer-row { position: absolute; left: 0; bottom: -3px; height: 6px; width: 100%; cursor: row-resize; z-index: 9; }
+.sheet-grid.sheet-frozen-r thead th { position: sticky; top: 0; z-index: 8; }
+.sheet-grid.sheet-frozen-r tbody tr:first-child th, .sheet-grid.sheet-frozen-r tbody tr:first-child td { position: sticky; top: var(--fr-top, 24px); z-index: 7; }
+.sheet-grid.sheet-frozen-c tbody th, .sheet-grid.sheet-frozen-c thead th:first-child { position: sticky; left: 0; z-index: 8; }
+.sheet-grid.sheet-frozen-c thead th:nth-child(2), .sheet-grid.sheet-frozen-c tbody td:first-of-type { position: sticky; left: var(--fc-left, 40px); z-index: 6; }
 .sheet-grid td:focus { box-shadow: inset 0 0 0 2px #64d29b; }
 .sheet-remote-tag { position: absolute; top: -15px; left: -1px; font: 10px/14px system-ui, sans-serif; padding: 0 4px; color: #fff; border-radius: 3px 3px 3px 0; white-space: nowrap; z-index: 5; pointer-events: none; }
 .sheet-remote-tag::after { content: attr(data-label); }
@@ -71,6 +87,10 @@ export class DomSheetView {
   // editable cell races the caret and re-renders can delete typed text.
   private fillHandle: HTMLSpanElement;
   private table: HTMLTableElement;
+  private thead: HTMLTableSectionElement;
+  private colHeads: HTMLTableCellElement[] = [];
+  private rowHeads: HTMLTableCellElement[] = [];
+  private rows: HTMLTableRowElement[] = [];
 
   constructor(root: HTMLElement, opts: SheetViewOptions) {
     this.opts = opts;
@@ -95,12 +115,18 @@ export class DomSheetView {
     });
     root.appendChild(this.fillHandle);
 
+    // ponytail: every cell is a DOM node (~200x52 = 10k contenteditables).
+    // Virtualization (render only the visible viewport) is the upgrade path
+    // when larger grids hurt; not built here.
     const thead = document.createElement('thead');
+    this.thead = thead;
     const headRow = document.createElement('tr');
     headRow.appendChild(document.createElement('th')); // corner
     for (let c = 0; c < opts.cols; c++) {
       const th = document.createElement('th');
       th.textContent = colName(c);
+      this.attachResizer(th, 'col', c);
+      this.colHeads.push(th);
       headRow.appendChild(th);
     }
     thead.appendChild(headRow);
@@ -109,8 +135,11 @@ export class DomSheetView {
     const tbody = document.createElement('tbody');
     for (let r = 0; r < opts.rows; r++) {
       const tr = document.createElement('tr');
+      this.rows.push(tr);
       const rowHead = document.createElement('th');
       rowHead.textContent = String(r + 1);
+      this.attachResizer(rowHead, 'row', r);
+      this.rowHeads.push(rowHead);
       tr.appendChild(rowHead);
       const rowCells: HTMLTableCellElement[] = [];
       for (let c = 0; c < opts.cols; c++) {
@@ -140,6 +169,56 @@ export class DomSheetView {
       this.render();
     });
     this.render();
+  }
+
+  // attachResizer adds a drag strip to a header cell edge. Dragging previews
+  // the size live via inline style and commits once on mouseup via onResize.
+  private attachResizer(th: HTMLTableCellElement, axis: 'col' | 'row', index: number): void {
+    if (this.opts.readOnly) return;
+    const grip = document.createElement('span');
+    grip.className = axis === 'col' ? 'sheet-resizer-col' : 'sheet-resizer-row';
+    grip.addEventListener('mousedown', (e: MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const startPos = axis === 'col' ? e.clientX : e.clientY;
+      const startSize = axis === 'col' ? th.offsetWidth : th.offsetHeight;
+      const minSize = axis === 'col' ? 40 : 18;
+      let size = startSize;
+      const onMove = (me: MouseEvent) => {
+        size = Math.max(minSize, startSize + ((axis === 'col' ? me.clientX : me.clientY) - startPos));
+        this.applyDim(axis, index, size);
+      };
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        this.opts.onResize?.(axis, index, size);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+    th.appendChild(grip);
+  }
+
+  // applyDim paints one dimension override. Column widths also need min-width
+  // relaxed on every cell in the column (the CSS default is min-width: 80px).
+  private applyDim(axis: 'col' | 'row', index: number, size: number | undefined): void {
+    const px = size === undefined ? '' : `${size}px`;
+    if (axis === 'col') {
+      const th = this.colHeads[index];
+      if (!th) return;
+      th.style.width = px;
+      th.style.minWidth = px;
+      th.style.maxWidth = px;
+      for (let r = 0; r < this.opts.rows; r++) {
+        const td = this.cells[r][index];
+        td.style.minWidth = px;
+        td.style.maxWidth = px;
+      }
+    } else {
+      const th = this.rowHeads[index];
+      if (!th) return;
+      th.style.height = px;
+    }
   }
 
   private ensureStyle(): void {
@@ -271,6 +350,18 @@ export class DomSheetView {
       td.querySelector('.sheet-remote-tag')?.remove();
     }
     this.decorated.clear();
+
+    // M4: dimension overrides, client-local row filter, freeze panes.
+    for (let c = 0; c < this.opts.cols; c++) this.applyDim('col', c, this.opts.colWidth?.(c));
+    for (let r = 0; r < this.opts.rows; r++) {
+      this.applyDim('row', r, this.opts.rowHeight?.(r));
+      this.rows[r].style.display = this.opts.rowHidden?.(r) ? 'none' : '';
+    }
+    const fz = this.opts.frozen?.() ?? { rows: 0, cols: 0 };
+    this.table.classList.toggle('sheet-frozen-r', fz.rows > 0);
+    this.table.classList.toggle('sheet-frozen-c', fz.cols > 0);
+    if (fz.rows > 0) this.table.style.setProperty('--fr-top', `${this.thead.offsetHeight}px`);
+    if (fz.cols > 0) this.table.style.setProperty('--fc-left', `${this.rowHeads[0]?.offsetWidth ?? 40}px`);
 
     for (let r = 0; r < this.opts.rows; r++) {
       for (let c = 0; c < this.opts.cols; c++) {

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -182,7 +182,9 @@ export class DomSheetView {
       e.preventDefault();
       const startPos = axis === 'col' ? e.clientX : e.clientY;
       const startSize = axis === 'col' ? th.offsetWidth : th.offsetHeight;
-      const minSize = axis === 'col' ? 40 : 18;
+      // ponytail: row floor matches the CSS td height (22px) — table cells
+      // treat height as min-height, so rows cannot render below it anyway.
+      const minSize = axis === 'col' ? 40 : 22;
       let size = startSize;
       const onMove = (me: MouseEvent) => {
         size = Math.max(minSize, startSize + ((axis === 'col' ? me.clientX : me.clientY) - startPos));
@@ -191,7 +193,7 @@ export class DomSheetView {
       const onUp = () => {
         document.removeEventListener('mousemove', onMove);
         document.removeEventListener('mouseup', onUp);
-        this.opts.onResize?.(axis, index, size);
+        if (size !== startSize) this.opts.onResize?.(axis, index, size);
       };
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);

--- a/ui/src/js/sheet/structural.test.ts
+++ b/ui/src/js/sheet/structural.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { WorkbookState } from './workbookState';
+import { transform } from './transform';
+import type { Op } from './op';
+
+const wb2 = (): WorkbookState => {
+  const w = new WorkbookState();
+  w.addSheet('s1', 'Sheet1');
+  w.addSheet('s2', 'Sheet2');
+  return w;
+};
+const ids = (w: WorkbookState) => w.sheets.map((s) => s.id);
+
+describe('sheet-list ops (mirrors Go structural_test)', () => {
+  it('add/rename/move/delete', () => {
+    const w = wb2();
+    w.applyOp({ type: 'addSheet', sheet: 's3', name: 'Drei', index: 1, baseRev: 0 });
+    expect(ids(w)).toEqual(['s1', 's3', 's2']);
+    w.applyOp({ type: 'addSheet', sheet: 's3', name: 'Nochmal', index: 0, baseRev: 0 });
+    expect(w.sheets.length).toBe(3); // duplicate add is a no-op
+    expect(w.sheetById('s3')?.name).toBe('Drei');
+    w.applyOp({ type: 'renameSheet', sheet: 's3', name: 'Umbenannt', baseRev: 0 });
+    expect(w.sheetById('s3')?.name).toBe('Umbenannt');
+    w.applyOp({ type: 'moveSheet', sheet: 's3', toIndex: 2, baseRev: 0 });
+    expect(ids(w)).toEqual(['s1', 's2', 's3']);
+    w.applyOp({ type: 'deleteSheet', sheet: 's3', baseRev: 0 });
+    expect(ids(w)).toEqual(['s1', 's2']);
+  });
+
+  it('never deletes the last sheet; ops on deleted sheets are no-ops', () => {
+    const w = new WorkbookState();
+    w.addSheet('s1', 'Sheet1');
+    w.applyOp({ type: 'deleteSheet', sheet: 's1', baseRev: 0 });
+    expect(w.sheets.length).toBe(1);
+    expect(() =>
+      w.applyOp({ type: 'setCell', sheet: 'gone', row: 0, col: 0, raw: 'x', baseRev: 0 }),
+    ).not.toThrow();
+  });
+});
+
+describe('dimensions + freeze', () => {
+  it('setDimension/setFreeze store metadata', () => {
+    const w = wb2();
+    w.applyOp({ type: 'setDimension', sheet: 's1', axis: 'col', index: 2, size: 140, baseRev: 0 });
+    w.applyOp({ type: 'setDimension', sheet: 's1', axis: 'row', index: 5, size: 40, baseRev: 0 });
+    w.applyOp({ type: 'setFreeze', sheet: 's1', frozenRows: 1, frozenCols: 1, baseRev: 0 });
+    const s = w.sheetById('s1')!;
+    expect(s.colWidths.get(2)).toBe(140);
+    expect(s.rowHeights.get(5)).toBe(40);
+    expect(s.frozenRows).toBe(1);
+    expect(s.frozenCols).toBe(1);
+  });
+
+  it('dims shift under structural ops; in-band deletes drop the override', () => {
+    const w = wb2();
+    w.applyOp({ type: 'setDimension', sheet: 's1', axis: 'col', index: 3, size: 120, baseRev: 0 });
+    w.applyOp({ type: 'insertCols', sheet: 's1', index: 0, count: 2, baseRev: 0 });
+    expect(w.sheetById('s1')!.colWidths.get(5)).toBe(120);
+    w.applyOp({ type: 'deleteCols', sheet: 's1', index: 4, count: 2, baseRev: 0 });
+    expect(w.sheetById('s1')!.colWidths.size).toBe(0);
+  });
+
+  it('snapshot round-trip loads dims/freeze', () => {
+    const w = new WorkbookState();
+    w.loadSnapshot({
+      sheets: [
+        { id: 's1', name: 'Sheet1', cells: [], colWidths: { '1': 99 }, rowHeights: { '2': 33 }, frozenRows: 1 },
+      ],
+    });
+    const s = w.sheetById('s1')!;
+    expect(s.colWidths.get(1)).toBe(99);
+    expect(s.rowHeights.get(2)).toBe(33);
+    expect(s.frozenRows).toBe(1);
+  });
+});
+
+describe('transform for setDimension (mirrors Go)', () => {
+  it('col dimension shifts under col insert; row axis untouched', () => {
+    const inOp: Op = { type: 'setDimension', sheet: 's1', axis: 'col', index: 3, size: 100, baseRev: 0 };
+    const applied: Op = { type: 'insertCols', sheet: 's1', index: 1, count: 2, baseRev: 0 };
+    expect(transform(inOp, applied).index).toBe(5);
+    expect(transform({ ...inOp, axis: 'row' }, applied).index).toBe(3);
+  });
+});

--- a/ui/src/js/sheet/transform.ts
+++ b/ui/src/js/sheet/transform.ts
@@ -32,6 +32,9 @@ function shiftRows(inOp: Op, index: number, delta: number): Op {
   if (out.type === 'insertRows' || out.type === 'deleteRows') {
     out.index = shiftCoord(out.index ?? 0, index, delta);
   }
+  if (out.type === 'setDimension' && out.axis === 'row') {
+    out.index = shiftCoord(out.index ?? 0, index, delta);
+  }
   return out;
 }
 
@@ -42,6 +45,9 @@ function shiftCols(inOp: Op, index: number, delta: number): Op {
     out.endCol = shiftCoord(out.endCol ?? 0, index, delta);
   }
   if (out.type === 'insertCols' || out.type === 'deleteCols') {
+    out.index = shiftCoord(out.index ?? 0, index, delta);
+  }
+  if (out.type === 'setDimension' && out.axis === 'col') {
     out.index = shiftCoord(out.index ?? 0, index, delta);
   }
   return out;

--- a/ui/src/js/sheet/workbookState.ts
+++ b/ui/src/js/sheet/workbookState.ts
@@ -220,10 +220,14 @@ export class WorkbookState {
         }
         break;
       }
-      case 'setDimension':
-        if (op.axis === 'col') sheet.colWidths.set(index, op.size ?? 0);
-        else sheet.rowHeights.set(index, op.size ?? 0);
+      case 'setDimension': {
+        // Mirror the Go server validation: axis col/row, size 1..4096.
+        const size = op.size ?? 0;
+        if ((op.axis !== 'col' && op.axis !== 'row') || !Number.isInteger(size) || size <= 0 || size > 4096) break;
+        if (op.axis === 'col') sheet.colWidths.set(index, size);
+        else sheet.rowHeights.set(index, size);
         break;
+      }
       case 'setFreeze':
         sheet.frozenRows = op.frozenRows ?? 0;
         sheet.frozenCols = op.frozenCols ?? 0;

--- a/ui/src/js/sheet/workbookState.ts
+++ b/ui/src/js/sheet/workbookState.ts
@@ -12,6 +12,10 @@ export interface SheetState {
   id: string;
   name: string;
   cells: Map<string, Cell>; // key "row:col"
+  colWidths: Map<number, number>; // sparse px overrides
+  rowHeights: Map<number, number>;
+  frozenRows: number; // 0 or 1
+  frozenCols: number;
 }
 
 const key = (row: number, col: number): string => `${row}:${col}`;
@@ -22,6 +26,27 @@ const parseKey = (k: string): [number, number] => {
 
 const cellIsEmpty = (c: Cell): boolean =>
   c.raw === '' && (c.styleId === undefined || c.styleId === 0) && (c.value === undefined || c.value === '');
+
+const emptySheet = (id: string, name: string): SheetState => ({
+  id, name, cells: new Map(), colWidths: new Map(), rowHeights: new Map(), frozenRows: 0, frozenCols: 0,
+});
+
+// shiftDims mirrors Go shiftDims: rebuild a sparse dimension map after an
+// insert (delta>0) / delete of -delta indices at index (in-band entries drop).
+const shiftDims = (m: Map<number, number>, index: number, delta: number): Map<number, number> => {
+  if (m.size === 0) return m;
+  const next = new Map<number, number>();
+  for (const [i, v] of m) {
+    if (delta < 0 && i >= index && i < index - delta) continue;
+    next.set(shiftIdx(i, index, delta), v);
+  }
+  return next;
+};
+
+const shiftIdx = (coord: number, index: number, delta: number): number => {
+  if (delta >= 0) return coord >= index ? coord + delta : coord;
+  return coord < index ? coord : coord + delta;
+};
 
 // Snapshot shapes mirror the Go sheet.WorkbookSnapshot JSON.
 export interface CellSnapshot {
@@ -36,6 +61,10 @@ export interface SheetSnapshot {
   id: string;
   name: string;
   cells: CellSnapshot[];
+  colWidths?: Record<string, number>; // JSON object keys are stringified indices
+  rowHeights?: Record<string, number>;
+  frozenRows?: number;
+  frozenCols?: number;
 }
 export interface WorkbookSnapshot {
   sheets: SheetSnapshot[];
@@ -53,7 +82,7 @@ export class WorkbookState {
   }
 
   addSheet(id: string, name: string): SheetState {
-    const s: SheetState = { id, name, cells: new Map() };
+    const s = emptySheet(id, name);
     this.sheets.push(s);
     return s;
   }
@@ -64,23 +93,31 @@ export class WorkbookState {
 
   clone(): WorkbookState {
     const cp = new WorkbookState();
-    cp.sheets = this.sheets.map((s) => ({ id: s.id, name: s.name, cells: new Map(s.cells) }));
+    cp.sheets = this.sheets.map((s) => ({
+      id: s.id, name: s.name, cells: new Map(s.cells),
+      colWidths: new Map(s.colWidths), rowHeights: new Map(s.rowHeights),
+      frozenRows: s.frozenRows, frozenCols: s.frozenCols,
+    }));
     cp.styles = this.styles; // shared pool: interning is monotonic + content-deduped
     return cp;
   }
 
   loadSnapshot(snap: WorkbookSnapshot): void {
     this.sheets = (snap.sheets ?? []).map((ss) => {
-      const cells = new Map<string, Cell>();
+      const s = emptySheet(ss.id, ss.name);
       for (const c of ss.cells ?? []) {
-        cells.set(key(c.row, c.col), {
+        s.cells.set(key(c.row, c.col), {
           raw: c.raw,
           value: c.value,
           valueType: c.valueType,
           styleId: c.styleId,
         });
       }
-      return { id: ss.id, name: ss.name, cells };
+      for (const [i, v] of Object.entries(ss.colWidths ?? {})) s.colWidths.set(Number(i), v);
+      for (const [i, v] of Object.entries(ss.rowHeights ?? {})) s.rowHeights.set(Number(i), v);
+      s.frozenRows = ss.frozenRows ?? 0;
+      s.frozenCols = ss.frozenCols ?? 0;
+      return s;
     });
     this.styles.seed(snap.styles);
   }
@@ -113,8 +150,37 @@ export class WorkbookState {
   // applyOp mirrors Go Workbook.Apply. The op is assumed already rebased to the
   // current revision. Cell ops are last-writer-wins.
   applyOp(op: Op): void {
+    // Sheet-list ops manage the sheet list itself (mirrors Go Apply).
+    switch (op.type) {
+      case 'addSheet': {
+        if (this.sheetById(op.sheet)) return; // concurrent duplicate add: first wins
+        const s = emptySheet(op.sheet, op.name ?? '');
+        this.sheets.splice(Math.min(op.index ?? 0, this.sheets.length), 0, s);
+        return;
+      }
+      case 'deleteSheet': {
+        if (this.sheets.length <= 1) return; // never delete the last sheet
+        const i = this.sheets.findIndex((s) => s.id === op.sheet);
+        if (i >= 0) this.sheets.splice(i, 1);
+        return;
+      }
+      case 'renameSheet': {
+        const s = this.sheetById(op.sheet);
+        if (s) s.name = op.name ?? s.name;
+        return;
+      }
+      case 'moveSheet': {
+        const i = this.sheets.findIndex((s) => s.id === op.sheet);
+        if (i < 0) return;
+        const [s] = this.sheets.splice(i, 1);
+        this.sheets.splice(Math.min(op.toIndex ?? 0, this.sheets.length), 0, s);
+        return;
+      }
+    }
+
     const sheet = this.sheetById(op.sheet);
-    if (!sheet) throw new Error(`applyOp: unknown sheet ${op.sheet}`);
+    // Deleted by an earlier-ordered op: converge as a no-op (mirrors Go Apply).
+    if (!sheet) return;
 
     const row = op.row ?? 0;
     const col = op.col ?? 0;
@@ -154,8 +220,17 @@ export class WorkbookState {
         }
         break;
       }
+      case 'setDimension':
+        if (op.axis === 'col') sheet.colWidths.set(index, op.size ?? 0);
+        else sheet.rowHeights.set(index, op.size ?? 0);
+        break;
+      case 'setFreeze':
+        sheet.frozenRows = op.frozenRows ?? 0;
+        sheet.frozenCols = op.frozenCols ?? 0;
+        break;
       case 'insertRows':
         this.remap(sheet, (r, c) => (r >= index ? [r + count, c, true] : [r, c, true]));
+        sheet.rowHeights = shiftDims(sheet.rowHeights, index, count);
         break;
       case 'deleteRows':
         this.remap(sheet, (r, c) => {
@@ -163,9 +238,11 @@ export class WorkbookState {
           if (r >= index + count) return [r - count, c, true];
           return [r, c, true];
         });
+        sheet.rowHeights = shiftDims(sheet.rowHeights, index, -count);
         break;
       case 'insertCols':
         this.remap(sheet, (r, c) => (c >= index ? [r, c + count, true] : [r, c, true]));
+        sheet.colWidths = shiftDims(sheet.colWidths, index, count);
         break;
       case 'deleteCols':
         this.remap(sheet, (r, c) => {
@@ -173,6 +250,7 @@ export class WorkbookState {
           if (c >= index + count) return [r, c - count, true];
           return [r, c, true];
         });
+        sheet.colWidths = shiftDims(sheet.colWidths, index, -count);
         break;
       default:
         throw new Error(`applyOp: unhandled op type ${(op as Op).type}`);


### PR DESCRIPTION
Final milestone of the Excel-comparable spreadsheet initiative (spec: docs/superpowers/specs/2026-07-01-excel-spreadsheet-design.md, plan: docs/superpowers/plans/2026-07-02-excel-m4-structural.md). Stacked on #324 — retarget to main once that merges.

## Multiple sheets
- New ops (Go + TS mirror): addSheet / renameSheet / deleteSheet / moveSheet. Duplicate add, last-sheet delete, and ops on a deleted sheet all converge as no-ops (a late op after a concurrent delete must not poison the ordered-log replay).
- Bottom tabs bar: click to switch, double-click to rename, right-click to delete, drag to reorder, + to add. Data is isolated per sheet.

## Column/row resize
- setDimension op; sparse ColWidths/RowHeights per sheet, snapshot round-trip, maps shift under structural insert/delete, Transform shifts the index on the matching axis.
- Drag grips on header edges with live preview; one op on mouseup; persists across reload.

## Freeze panes
- setFreeze op (first row and/or first col; arbitrary freeze is the upgrade path). CSS position:sticky — required switching the grid to border-collapse:separate with right/bottom-only borders (sticky drops collapsed borders).

## Sort / filter
- Sort A-Z / Z-A over the selected range by the focused column, emitted as a batch of setCell ops; moved formulas shift row refs via the fill heuristic. Numbers compare numerically; empty cells always sort last.
- Filter: client-local row hiding by distinct values of the focused column (blank rows stay visible). Not collaborative in v1.

## Grid
- 200 rows x 52 cols (A-AZ). ponytail ceiling: DOM node per cell; virtualization is the upgrade path.

## Tests
- Go: lib/sheet/structural_test.go (apply/validate/transform/convergence/snapshot/dim-shift).
- TS: structural.test.ts, sheetSortFilter.test.ts (80 sheet unit tests green).
- E2E: playwright/specs/sheet_structural.spec.ts — 5 scenarios, ran live 5/5 green; all 10 existing sheet specs green against the same build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)