### PR TITLE
feat(sheet): 1:1 Excel chrome — classic ribbon, title/status bar, font props, xlsx

### DIFF
--- a/lib/sheet/op.go
+++ b/lib/sheet/op.go
@@ -3,6 +3,7 @@ package sheet
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 )
 
 type OpType string
@@ -152,7 +153,13 @@ func (o Op) Validate() error {
 var (
 	hexColorRe = regexp.MustCompile(`^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`)
 	numFmtRe   = regexp.MustCompile(`^(general|text|date|(number|currency|percent)(:\d{1,2})?)$`)
+	fontSizeRe = regexp.MustCompile(`^[1-9]\d?$`) // 1-2 digits, no leading zeros; range-checked below
 )
+
+var fontFamilies = map[string]bool{
+	"Calibri": true, "Arial": true, "Times New Roman": true,
+	"Courier New": true, "Georgia": true, "Verdana": true,
+}
 
 // validateProps allowlists style prop keys and values. Props come from
 // arbitrary collaborators and end up as inline CSS on every viewer's DOM, so
@@ -171,6 +178,15 @@ func validateProps(props map[string]string) error {
 			ok = v == "all"
 		case "numFmt":
 			ok = numFmtRe.MatchString(v)
+		case "fontFamily":
+			ok = fontFamilies[v]
+		case "fontSize":
+			if fontSizeRe.MatchString(v) {
+				n, _ := strconv.Atoi(v)
+				ok = n >= 6 && n <= 96
+			}
+		case "wrap":
+			ok = v == "1"
 		default:
 			return fmt.Errorf("props: unknown key %q", k)
 		}

--- a/lib/sheet/op_test.go
+++ b/lib/sheet/op_test.go
@@ -51,6 +51,7 @@ func TestOpValidateProps(t *testing.T) {
 		"bold": "1", "italic": "1", "underline": "1",
 		"color": "#c00", "bg": "#ffcc00", "align": "center",
 		"border": "all", "numFmt": "currency:2",
+		"fontFamily": "Times New Roman", "fontSize": "96", "wrap": "1",
 	}
 	if err := (Op{Type: OpSetStyle, Sheet: "s1", Props: ok}).Validate(); err != nil {
 		t.Fatalf("valid props rejected: %v", err)
@@ -63,6 +64,12 @@ func TestOpValidateProps(t *testing.T) {
 		{"numFmt": "number:999"},               // decimals capped at 2 digits
 		{"expression": "alert(1)"},             // unknown key
 		{"border": "1px solid url(https://x)"}, // only "all"
+		{"fontFamily": "Comic Sans MS"},        // outside allowlist
+		{"fontSize": "0"},                      // below range
+		{"fontSize": "97"},                     // above range
+		{"fontSize": "012"},                    // leading zero
+		{"fontSize": "12.5"},                   // not an integer
+		{"wrap": "yes"},                        // only "1"
 	}
 	for _, props := range bad {
 		if (Op{Type: OpSetStyle, Sheet: "s1", Props: props}).Validate() == nil {

--- a/playwright/specs/sheet_excel_chrome.spec.ts
+++ b/playwright/specs/sheet_excel_chrome.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// 0-based cell locator. Row header is th (child 1), so data column c is
+// td:nth-child(c + 2); data row r is tbody tr:nth-child(r + 1). Mirrors
+// sheet_selection.spec.ts.
+const cell = (page: Page, r: number, c: number) =>
+  page.locator(`.sheet-grid tbody tr:nth-child(${r + 1}) td:nth-child(${c + 2})`);
+
+async function openSheet(page: Page, padId: string): Promise<void> {
+  await page.goto(`/s/${padId}`);
+  await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+}
+
+async function commitCell(page: Page, r: number, c: number, text: string): Promise<void> {
+  await cell(page, r, c).click();
+  await page.keyboard.type(text, { delay: 30 });
+  await page.keyboard.press('Enter');
+}
+
+// Real mouse drag selection (mousedown -> mouseover -> mouseup), matching
+// DomSheetView's listeners. Mirrors sheet_selection.spec.ts.
+async function dragSelect(page: Page, r0: number, c0: number, r1: number, c1: number): Promise<void> {
+  await cell(page, r0, c0).hover();
+  await page.mouse.down();
+  await cell(page, r1, c1).hover();
+  await page.mouse.up();
+}
+
+test.describe('Sheet Excel chrome', () => {
+  test('titlebar shows the pad name', async ({ page }) => {
+    const padId = `xl-title-${Date.now()}`;
+    await openSheet(page, padId);
+
+    const titlebar = page.locator('.sheet-titlebar');
+    await expect(titlebar).toBeVisible();
+    await expect(titlebar).toContainText(padId);
+  });
+
+  test('font family and size selects restyle the selection', async ({ page }) => {
+    const padId = `xl-font-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'hi'); // A1
+
+    // Home tab is the default; selects are only unique by title.
+    await cell(page, 0, 0).click();
+    await page.locator('select[title="Font"]').selectOption({ label: 'Arial' });
+    await page.locator('select[title="Font size"]').selectOption({ label: '20' });
+
+    await expect(cell(page, 0, 0)).toHaveCSS('font-family', /Arial/);
+    // 20pt = 26.667px computed.
+    await expect(cell(page, 0, 0)).toHaveCSS('font-size', /^26\.6/);
+  });
+
+  test('wrap text switches the cell to normal white-space', async ({ page }) => {
+    const padId = `xl-wrap-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'a rather long text that overflows the default column width'); // A1
+
+    // Default: no wrapping (overflow is clipped instead).
+    const before = await cell(page, 0, 0).evaluate((el) => getComputedStyle(el).whiteSpace);
+    expect(before).not.toBe('normal');
+
+    await cell(page, 0, 0).click();
+    await page.locator('.sheet-toolbar button[title="Wrap text"]').click();
+
+    await expect(cell(page, 0, 0)).toHaveCSS('white-space', 'normal');
+  });
+
+  test('AutoSum seeds =SUM( in the formula bar and commits the sum', async ({ page }) => {
+    const padId = `xl-autosum-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, '2'); // A1
+    await commitCell(page, 1, 0, '3'); // A2
+
+    await cell(page, 3, 0).click(); // A4
+    await page.locator('.sheet-toolbar button[title="AutoSum"]').click();
+
+    const fx = page.locator('.sheet-fx-input');
+    await expect(fx).toBeFocused();
+    await expect(fx).toHaveValue(/^=SUM\(/);
+
+    // The caret sits inside the parens of '=SUM()' -> typing produces '=SUM(A1:A2)'.
+    await page.keyboard.type('A1:A2');
+    await page.keyboard.press('Enter');
+
+    await expect(cell(page, 3, 0)).toHaveText('5');
+  });
+
+  test('formula-bar cancel reverts, commit applies', async ({ page }) => {
+    const padId = `xl-fx-btns-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'alt'); // A1
+
+    await cell(page, 0, 0).click();
+    const fx = page.locator('.sheet-fx-input');
+    await fx.click();
+    await fx.fill('neu');
+    await page.locator('.sheet-fx-cancel').click();
+    await expect(cell(page, 0, 0)).toHaveText('alt');
+
+    await fx.click();
+    await fx.fill('neu2');
+    await page.locator('.sheet-fx-commit').click();
+    await expect(cell(page, 0, 0)).toHaveText('neu2');
+  });
+
+  test('statusbar shows average, count, and sum for a numeric selection', async ({ page }) => {
+    const padId = `xl-stats-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, '1'); // A1
+    await commitCell(page, 1, 0, '2'); // A2
+    await commitCell(page, 2, 0, '3'); // A3
+
+    await dragSelect(page, 0, 0, 2, 0); // A1:A3
+
+    const stats = page.locator('.sheet-statusbar .sheet-stats');
+    await expect(stats).toContainText('Average: 2');
+    await expect(stats).toContainText('Count: 3');
+    await expect(stats).toContainText('Sum: 6');
+  });
+
+  test('ribbon Copy/Paste buttons roundtrip a cell', async ({ browser, browserName }) => {
+    // Firefox rejects clipboard-read/write permission grants at context
+    // creation (see sheet_selection.spec.ts).
+    test.skip(browserName === 'firefox', 'Firefox does not support clipboard-read/write permission grants in Playwright');
+
+    const ctx = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] });
+    const page = await ctx.newPage();
+    const padId = `xl-clip-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'x'); // A1
+
+    await cell(page, 0, 0).click();
+    await page.locator('.sheet-toolbar button[title="Copy"]').click();
+    await cell(page, 0, 1).click(); // B1
+    await page.locator('.sheet-toolbar button[title="Paste"]').click();
+
+    await expect(cell(page, 0, 1)).toHaveText('x', { timeout: 10000 });
+    await ctx.close();
+  });
+
+  test('selected cell highlights its row and column headers', async ({ page }) => {
+    const padId = `xl-headhl-${Date.now()}`;
+    await openSheet(page, padId);
+
+    await cell(page, 1, 1).click(); // B2
+
+    // thead: corner th (0) + 'A' (1) + 'B' (2); row header is the tr's th.
+    await expect(page.locator('.sheet-grid thead th').nth(2)).toHaveClass(/sheet-head-hl/);
+    await expect(page.locator('.sheet-grid tbody tr:nth-child(2) th')).toHaveClass(/sheet-head-hl/);
+  });
+});

--- a/playwright/specs/sheet_formatting.spec.ts
+++ b/playwright/specs/sheet_formatting.spec.ts
@@ -38,8 +38,8 @@ test.describe('Sheet formatting', () => {
     await commitCell(page, 0, 0, '1234.5'); // A1
 
     await cell(page, 0, 0).click();
-    // Number-format select is the FIRST select in the toolbar (Home tab, default).
-    await page.locator('.sheet-toolbar select').first().selectOption('number:2');
+    // Toolbar selects are only unique by title (the Excel ribbon reordered them).
+    await page.locator('select[title="Number format"]').selectOption('number:2');
 
     await expect(cell(page, 0, 0)).toHaveText('1,234.50');
   });

--- a/playwright/specs/sheet_formatting.spec.ts
+++ b/playwright/specs/sheet_formatting.spec.ts
@@ -24,9 +24,9 @@ test.describe('Sheet formatting', () => {
 
     await commitCell(page, 0, 0, 'hi'); // A1
 
-    // Re-select A1, then toggle bold via the toolbar.
+    // Re-select A1, then toggle bold via the ribbon (Home tab is the default).
     await cell(page, 0, 0).click();
-    await page.locator('.sheet-toolbar button[data-key=bold]').click();
+    await page.locator('.sheet-toolbar button').filter({ hasText: /^B$/ }).click();
 
     await expect(cell(page, 0, 0)).toHaveCSS('font-weight', /700|bold/);
   });
@@ -38,7 +38,8 @@ test.describe('Sheet formatting', () => {
     await commitCell(page, 0, 0, '1234.5'); // A1
 
     await cell(page, 0, 0).click();
-    await page.locator('.sheet-toolbar select[title="Number format"]').selectOption('number:2');
+    // Number-format select is the FIRST select in the toolbar (Home tab, default).
+    await page.locator('.sheet-toolbar select').first().selectOption('number:2');
 
     await expect(cell(page, 0, 0)).toHaveText('1,234.50');
   });

--- a/playwright/specs/sheet_ribbon.spec.ts
+++ b/playwright/specs/sheet_ribbon.spec.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import { test, expect, type Page } from '@playwright/test';
+
+// 0-based cell locator. Row header is th (child 1), so data column c is
+// td:nth-child(c + 2); data row r is tbody tr:nth-child(r + 1). Mirrors
+// sheet_structural.spec.ts.
+const cell = (page: Page, r: number, c: number) =>
+  page.locator(`.sheet-grid tbody tr:nth-child(${r + 1}) td:nth-child(${c + 2})`);
+
+async function openSheet(page: Page, padId: string): Promise<void> {
+  await page.goto(`/s/${padId}`);
+  await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+}
+
+async function typeInto(page: Page, r: number, c: number, text: string): Promise<void> {
+  await cell(page, r, c).click();
+  await page.keyboard.type(text);
+  await page.keyboard.press('Enter');
+}
+
+// Ribbon groups of inactive tabs are display:none — activate the tab first.
+async function ribbonTab(page: Page, name: 'Home' | 'Data' | 'View'): Promise<void> {
+  await page.locator('.sheet-ribbon-tabs button', { hasText: name }).click();
+}
+
+const toolbarButton = (page: Page, text: string | RegExp) =>
+  page.locator('.sheet-toolbar button').filter({ hasText: text });
+
+test.describe('Sheet ribbon', () => {
+  test('tab switch shows the active group and hides the rest', async ({ page }) => {
+    await openSheet(page, `ribbon-tabs-${Date.now()}`);
+
+    // Home is the default tab: bold visible, sort hidden.
+    await expect(toolbarButton(page, /^B$/)).toBeVisible();
+
+    await ribbonTab(page, 'Data');
+    await expect(toolbarButton(page, 'A→Z')).toBeVisible();
+    await expect(toolbarButton(page, /^B$/)).toBeHidden();
+
+    await ribbonTab(page, 'Home');
+    await expect(toolbarButton(page, /^B$/)).toBeVisible();
+    await expect(toolbarButton(page, 'A→Z')).toBeHidden();
+  });
+
+  test('insert row above shifts rows down; delete selected rows restores', async ({ page }) => {
+    await openSheet(page, `ribbon-rows-${Date.now()}`);
+    await typeInto(page, 0, 0, 'x'); // A1
+    await typeInto(page, 1, 0, 'y'); // A2
+
+    await cell(page, 1, 0).click(); // focus A2
+    await ribbonTab(page, 'Home');
+    await page.locator('.sheet-toolbar button[title="Insert row above"]').click();
+    await expect(cell(page, 0, 0)).toHaveText('x');
+    await expect(cell(page, 1, 0)).toHaveText('');
+    await expect(cell(page, 2, 0)).toHaveText('y');
+
+    await cell(page, 1, 0).click(); // select the inserted row 2
+    await page.locator('.sheet-toolbar button[title="Delete selected rows"]').click();
+    await expect(cell(page, 1, 0)).toHaveText('y');
+  });
+
+  test('insert column left shifts columns right', async ({ page }) => {
+    await openSheet(page, `ribbon-cols-${Date.now()}`);
+    await typeInto(page, 0, 1, 'b'); // B1
+
+    await cell(page, 0, 1).click(); // focus B1
+    await ribbonTab(page, 'Home');
+    await page.locator('.sheet-toolbar button[title="Insert column left"]').click();
+    await expect(cell(page, 0, 1)).toHaveText('');
+    await expect(cell(page, 0, 2)).toHaveText('b');
+  });
+
+  test('export downloads an .xlsx file', async ({ page }) => {
+    await openSheet(page, `ribbon-export-${Date.now()}`);
+    await typeInto(page, 0, 0, 'wert');
+
+    await ribbonTab(page, 'Data');
+    const downloadPromise = page.waitForEvent('download');
+    await toolbarButton(page, '⬇ Export').click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
+  });
+
+  test('import roundtrips an exported workbook', async ({ page }) => {
+    await openSheet(page, `ribbon-import-${Date.now()}`);
+    await typeInto(page, 0, 0, 'alpha'); // A1
+    await typeInto(page, 1, 1, 'beta'); // B2
+
+    await ribbonTab(page, 'Data');
+    const downloadPromise = page.waitForEvent('download');
+    await toolbarButton(page, '⬇ Export').click();
+    const download = await downloadPromise;
+    const buffer = fs.readFileSync(await download.path());
+
+    const chooserPromise = page.waitForEvent('filechooser');
+    await toolbarButton(page, '⬆ Import').click();
+    const chooser = await chooserPromise;
+    // Import triggers SHEET_RELOAD — arm the load waiter before setFiles.
+    const reloaded = page.waitForEvent('load', { timeout: 20000 });
+    await chooser.setFiles({
+      name: 'wb.xlsx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      buffer,
+    });
+    await reloaded;
+    await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+
+    await expect(cell(page, 0, 0)).toHaveText('alpha');
+    await expect(cell(page, 1, 1)).toHaveText('beta');
+  });
+});

--- a/playwright/specs/sheet_ribbon.spec.ts
+++ b/playwright/specs/sheet_ribbon.spec.ts
@@ -100,14 +100,20 @@ test.describe('Sheet ribbon', () => {
     const chooserPromise = page.waitForEvent('filechooser');
     await importBtn(page).click();
     const chooser = await chooserPromise;
-    // Import triggers SHEET_RELOAD — arm the load waiter before setFiles.
-    const reloaded = page.waitForEvent('load', { timeout: 20000 });
+    // Import triggers SHEET_RELOAD (location.reload). Firefox does not reliably
+    // surface that as a page "load" event, so detect the reload via a window
+    // sentinel that only survives until navigation.
+    await page.evaluate(() => { (window as { __preImport?: number }).__preImport = 1; });
     await chooser.setFiles({
       name: 'wb.xlsx',
       mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       buffer,
     });
-    await reloaded;
+    await page.waitForFunction(
+      () => (window as { __preImport?: number }).__preImport === undefined,
+      undefined,
+      { timeout: 20000 },
+    );
     await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
 
     await expect(cell(page, 0, 0)).toHaveText('alpha');

--- a/playwright/specs/sheet_ribbon.spec.ts
+++ b/playwright/specs/sheet_ribbon.spec.ts
@@ -26,6 +26,11 @@ async function ribbonTab(page: Page, name: 'Home' | 'Data' | 'View'): Promise<vo
 const toolbarButton = (page: Page, text: string | RegExp) =>
   page.locator('.sheet-toolbar button').filter({ hasText: text });
 
+// Import/Export buttons are only unique by title in the Excel ribbon (the
+// File menu carries similar labels).
+const exportBtn = (page: Page) => page.locator('.sheet-toolbar button[title="Export as .xlsx"]');
+const importBtn = (page: Page) => page.locator('.sheet-toolbar button[title="Import .xlsx (replaces this sheet)"]');
+
 test.describe('Sheet ribbon', () => {
   test('tab switch shows the active group and hides the rest', async ({ page }) => {
     await openSheet(page, `ribbon-tabs-${Date.now()}`);
@@ -76,7 +81,7 @@ test.describe('Sheet ribbon', () => {
 
     await ribbonTab(page, 'Data');
     const downloadPromise = page.waitForEvent('download');
-    await toolbarButton(page, '⬇ Export').click();
+    await exportBtn(page).click();
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
   });
@@ -88,12 +93,12 @@ test.describe('Sheet ribbon', () => {
 
     await ribbonTab(page, 'Data');
     const downloadPromise = page.waitForEvent('download');
-    await toolbarButton(page, '⬇ Export').click();
+    await exportBtn(page).click();
     const download = await downloadPromise;
     const buffer = fs.readFileSync(await download.path());
 
     const chooserPromise = page.waitForEvent('filechooser');
-    await toolbarButton(page, '⬆ Import').click();
+    await importBtn(page).click();
     const chooser = await chooserPromise;
     // Import triggers SHEET_RELOAD — arm the load waiter before setFiles.
     const reloaded = page.waitForEvent('load', { timeout: 20000 });

--- a/playwright/specs/sheet_structural.spec.ts
+++ b/playwright/specs/sheet_structural.spec.ts
@@ -96,15 +96,17 @@ test.describe('Sheet M4 structural', () => {
     await typeInto(page, 2, 0, 'x');
     await cell(page, 0, 0).click();
     await ribbonTab(page, 'Data');
-    // The dropdown fills its options lazily on open; selectOption() bypasses
-    // the native open, so trigger the repopulation explicitly first.
-    await page.locator('.sheet-toolbar select').last().dispatchEvent('mousedown');
-    await page.locator('.sheet-toolbar select').last().selectOption('x');
+    // Toolbar selects are only unique by title (the Excel ribbon reordered
+    // them). The dropdown fills its options lazily on open; selectOption()
+    // bypasses the native open, so trigger the repopulation explicitly first.
+    const filter = page.locator('select[title="Filter rows by the focused column"]');
+    await filter.dispatchEvent('mousedown');
+    await filter.selectOption('x');
     await expect(page.locator('.sheet-grid tbody tr').nth(1)).toBeHidden();
     await expect(page.locator('.sheet-grid tbody tr').nth(0)).toBeVisible();
     await expect(page.locator('.sheet-grid tbody tr').nth(2)).toBeVisible();
     // clear
-    await page.locator('.sheet-toolbar select').last().selectOption('');
+    await filter.selectOption('');
     await expect(page.locator('.sheet-grid tbody tr').nth(1)).toBeVisible();
   });
 });

--- a/playwright/specs/sheet_structural.spec.ts
+++ b/playwright/specs/sheet_structural.spec.ts
@@ -14,6 +14,11 @@ async function typeInto(page: Page, r: number, c: number, text: string): Promise
   await page.keyboard.press('Enter');
 }
 
+// Ribbon groups of inactive tabs are display:none — activate the tab first.
+async function ribbonTab(page: Page, name: 'Home' | 'Data' | 'View'): Promise<void> {
+  await page.locator('.sheet-ribbon-tabs button', { hasText: name }).click();
+}
+
 test.describe('Sheet M4 structural', () => {
   test('tabs: add, switch, rename; data stays per sheet', async ({ page }) => {
     await openSheet(page, `m4-tabs-${Date.now()}`);
@@ -58,7 +63,8 @@ test.describe('Sheet M4 structural', () => {
   test('freeze first row makes it sticky', async ({ page }) => {
     await openSheet(page, `m4-freeze-${Date.now()}`);
     await typeInto(page, 0, 0, 'kopf');
-    await page.locator('.sheet-toolbar button', { hasText: '❄R' }).click();
+    await ribbonTab(page, 'View');
+    await page.locator('.sheet-toolbar button', { hasText: '❄ Row' }).click();
     await page.waitForTimeout(400);
     await expect(page.locator('.sheet-grid')).toHaveClass(/sheet-frozen-r/);
     const sticky = await cell(page, 0, 0).evaluate((el) => getComputedStyle(el).position);
@@ -75,6 +81,7 @@ test.describe('Sheet M4 structural', () => {
     await page.mouse.down();
     await cell(page, 2, 0).hover();
     await page.mouse.up();
+    await ribbonTab(page, 'Data');
     await page.locator('.sheet-toolbar button', { hasText: 'A→Z' }).click();
     await page.waitForTimeout(600);
     await expect(cell(page, 0, 0)).toHaveText('1');
@@ -88,6 +95,7 @@ test.describe('Sheet M4 structural', () => {
     await typeInto(page, 1, 0, 'y');
     await typeInto(page, 2, 0, 'x');
     await cell(page, 0, 0).click();
+    await ribbonTab(page, 'Data');
     // The dropdown fills its options lazily on open; selectOption() bypasses
     // the native open, so trigger the repopulation explicitly first.
     await page.locator('.sheet-toolbar select').last().dispatchEvent('mousedown');

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -24,6 +24,19 @@ interface SheetVarsData {
   readonly: boolean;
 }
 
+// Editor-level chrome (title bar above the ribbon, status bar below the tabs).
+const CHROME_CSS = `
+.sheet-titlebar { display: flex; align-items: center; gap: 8px; height: 36px; padding: 0 12px; background: #107c41; color: #fff; font: 14px system-ui, sans-serif; }
+.sheet-titlebar svg { flex: none; display: block; }
+.sheet-title-name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sheet-statusbar { display: flex; align-items: center; justify-content: space-between; height: 22px; padding: 0 10px; background: #f5f6f7; border-top: 1px solid #d4d8dd; font: 12px system-ui, sans-serif; color: #444; }
+.sheet-stats { display: flex; gap: 16px; }
+`;
+const TITLE_ICON_SVG =
+  '<svg width="18" height="18" viewBox="0 0 16 16" aria-hidden="true">' +
+  '<rect x="1" y="1" width="14" height="14" rx="1.5" fill="none" stroke="#fff" stroke-width="1.4"/>' +
+  '<path d="M1 5.7h14M1 10.3h14M5.7 1v14M10.3 1v14" stroke="#fff" stroke-width="1" fill="none"/></svg>';
+
 // startSheetEditor connects to the collaborative spreadsheet backend, performs
 // the CLIENT_READY handshake (component "sheet"), and wires the collaboration
 // client, formula engine, grid view and ephemeral presence.
@@ -105,6 +118,38 @@ export function startSheetEditor(root: HTMLElement): void {
   const rawValue = (r: number, c: number): string =>
     collab?.display.getCell(activeSheetId, r, c)?.raw ?? '';
 
+  // Status-bar stats (Excel wording): Average/Sum over numeric raw values,
+  // Count = non-empty cells. Shown only for multi-cell selections with at
+  // least one numeric cell; empty otherwise.
+  let statsEl: HTMLElement | null = null;
+  const updateStats = (): void => {
+    if (!statsEl) return;
+    statsEl.textContent = '';
+    if (selIsSingle(selection)) return;
+    let sum = 0;
+    let numCount = 0;
+    let count = 0;
+    for (const { row, col } of selCells(selection)) {
+      const raw = rawValue(row, col);
+      if (raw === '') continue;
+      count++;
+      const n = Number(raw);
+      if (raw.trim() !== '' && Number.isFinite(n)) {
+        sum += n;
+        numCount++;
+      }
+    }
+    if (numCount === 0) return;
+    // toPrecision(12) strips float noise (0.1+0.2 -> 0.3) without truncating
+    // typical spreadsheet magnitudes.
+    const f = (n: number): string => String(parseFloat(n.toPrecision(12)));
+    for (const part of [`Average: ${f(sum / numCount)}`, `Count: ${count}`, `Sum: ${f(sum)}`]) {
+      const s = document.createElement('span');
+      s.textContent = part;
+      statsEl.appendChild(s);
+    }
+  };
+
   // ponytail: styleId is client-internal — only `props` travel on the wire and
   // are persisted, and each cell's styleId+pool entry are set together in one
   // applyOp. So an optimistic local put() assigning a different nextId than the
@@ -165,6 +210,7 @@ export function startSheetEditor(root: HTMLElement): void {
       const { r0, c0, r1, c1 } = normalize(selection);
       formulaBar.setActive(rangeRefA1(r0, c0, r1, c1), rawValue(selection.focus.row, selection.focus.col));
     }
+    updateStats();
   };
 
   const editingNow = (): boolean => view?.isEditing() ?? false;
@@ -181,6 +227,20 @@ export function startSheetEditor(root: HTMLElement): void {
     // toolbar gets its own sibling container (gridHost) rather than sharing
     // root with it.
     root.innerHTML = '';
+    if (!document.getElementById('sheet-chrome-style')) {
+      const s = document.createElement('style');
+      s.id = 'sheet-chrome-style';
+      s.textContent = CHROME_CSS;
+      document.head.appendChild(s);
+    }
+    const titlebar = document.createElement('div');
+    titlebar.className = 'sheet-titlebar';
+    titlebar.innerHTML = TITLE_ICON_SVG;
+    const titleName = document.createElement('span');
+    titleName.className = 'sheet-title-name';
+    titleName.textContent = padId;
+    titlebar.appendChild(titleName);
+    root.appendChild(titlebar);
     const toolbar = createToolbar({
       getProps: (r, c) => propsOf(r, c),
       focusCell: () => selection.focus,
@@ -238,6 +298,17 @@ export function startSheetEditor(root: HTMLElement): void {
           })
           .catch((err) => alert(String(err)));
       },
+      // NOTE: clipboardAction/autoSum are added to ToolbarCallbacks in a
+      // parallel sheetToolbar.ts change; until it lands tsc flags these two
+      // object-literal properties as unknown here (expected).
+      clipboardAction: (a: 'cut' | 'copy' | 'paste') => {
+        if (a === 'copy') doCopy();
+        else if (a === 'cut') doCut();
+        else doPaste();
+      },
+      autoSum: () => {
+        if (!readOnly) formulaBar?.beginFormula('=SUM(');
+      },
     });
     formulaBar = createFormulaBar({
       readOnly: data.readonly,
@@ -287,6 +358,15 @@ export function startSheetEditor(root: HTMLElement): void {
     });
     root.appendChild(tabs.el);
 
+    const statusbar = document.createElement('div');
+    statusbar.className = 'sheet-statusbar';
+    const readyEl = document.createElement('span');
+    readyEl.textContent = 'Ready';
+    statsEl = document.createElement('span');
+    statsEl.className = 'sheet-stats';
+    statusbar.append(readyEl, statsEl);
+    root.appendChild(statusbar);
+
     view = new DomSheetView(gridHost, {
       rows: GRID_ROWS,
       cols: GRID_COLS,
@@ -324,6 +404,7 @@ export function startSheetEditor(root: HTMLElement): void {
         sendPresence(sel.anchor.row, sel.anchor.col, false, undefined, sel.focus.row, sel.focus.col);
         const { r0, c0, r1, c1 } = normalize(sel);
         formulaBar?.setActive(rangeRefA1(r0, c0, r1, c1), rawValue(sel.focus.row, sel.focus.col));
+        updateStats();
       },
       onLiveEdit: (r, c, raw) => sendLiveEdit(r, c, raw),
       onEditEnd: (r, c, committed) => {
@@ -354,35 +435,47 @@ export function startSheetEditor(root: HTMLElement): void {
     const el = document.activeElement as HTMLElement | null;
     if (el && el.tagName === 'TD' && el.isContentEditable) el.blur();
   };
+  // doCopy/doCut/doPaste back both the Ctrl+C/X/V shortcuts and the ribbon's
+  // clipboardAction buttons (same semantics: TSV, blur before ops, readOnly guards).
+  const doCopy = (): void => {
+    // ponytail: async Clipboard API only (requires secure context); a
+    // hidden-textarea fallback is the upgrade path for plain-HTTP deploys.
+    void navigator.clipboard.writeText(rangeToTSV(selection, rawValue));
+  };
+  const doCut = (): void => {
+    void navigator.clipboard.writeText(rangeToTSV(selection, rawValue));
+    if (readOnly || !collab) return;
+    blurActiveCell();
+    const { r0, c0, r1, c1 } = normalize(selection);
+    collab.applyLocal({ type: 'clearRange', sheet: activeSheetId, baseRev: collab.rev, row: r0, col: c0, endRow: r1, endCol: c1 });
+  };
+  const doPaste = (): void => {
+    if (readOnly || !collab) return;
+    blurActiveCell();
+    void navigator.clipboard.readText().then((text) => {
+      if (text === '') return;
+      if (!collab) return;
+      const grid = parseTSV(text);
+      const { r0, c0 } = normalize(selection);
+      for (const op of pasteOps(grid, { row: r0, col: c0 }, activeSheetId, collab.rev)) collab.applyLocal(op);
+    });
+  };
   document.addEventListener('keydown', (e) => {
     if (!collab) return;
     const mod = e.ctrlKey || e.metaKey;
     if (mod && (e.key === 'c' || e.key === 'C') && !editingNow()) {
       e.preventDefault();
-      // ponytail: async Clipboard API only (requires secure context); a
-      // hidden-textarea fallback is the upgrade path for plain-HTTP deploys.
-      void navigator.clipboard.writeText(rangeToTSV(selection, rawValue));
+      doCopy();
       return;
     }
     if (mod && (e.key === 'x' || e.key === 'X') && !editingNow()) {
       e.preventDefault();
-      void navigator.clipboard.writeText(rangeToTSV(selection, rawValue));
-      if (readOnly) return;
-      blurActiveCell();
-      const { r0, c0, r1, c1 } = normalize(selection);
-      collab.applyLocal({ type: 'clearRange', sheet: activeSheetId, baseRev: collab.rev, row: r0, col: c0, endRow: r1, endCol: c1 });
+      doCut();
       return;
     }
     if (mod && (e.key === 'v' || e.key === 'V') && !editingNow() && !readOnly) {
       e.preventDefault();
-      blurActiveCell();
-      void navigator.clipboard.readText().then((text) => {
-        if (text === '') return;
-        if (!collab) return;
-        const grid = parseTSV(text);
-        const { r0, c0 } = normalize(selection);
-        for (const op of pasteOps(grid, { row: r0, col: c0 }, activeSheetId, collab.rev)) collab.applyLocal(op);
-      });
+      doPaste();
       return;
     }
     if ((e.key === 'Delete' || e.key === 'Backspace') && !editingNow() && !readOnly && !selIsSingle(selection)) {

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -209,6 +209,35 @@ export function startSheetEditor(root: HTMLElement): void {
         hiddenRows = value === null ? new Set() : hiddenRowsForFilter(selection.focus.col, value, GRID_ROWS, rawValue);
         view?.render();
       },
+      // Explicit param types: until the ToolbarCallbacks interface gains these
+      // optional fields (built in parallel), there is no contextual type.
+      structural: (action: 'insRowAbove' | 'insRowBelow' | 'insColLeft' | 'insColRight' | 'delRows' | 'delCols') => {
+        if (readOnly || !collab) return;
+        blurActiveCell();
+        const { r0, c0, r1, c1 } = normalize(selection);
+        const ops: Record<typeof action, Op> = {
+          insRowAbove: { type: 'insertRows', sheet: activeSheetId, baseRev: collab.rev, index: r0, count: 1 },
+          insRowBelow: { type: 'insertRows', sheet: activeSheetId, baseRev: collab.rev, index: r1 + 1, count: 1 },
+          insColLeft: { type: 'insertCols', sheet: activeSheetId, baseRev: collab.rev, index: c0, count: 1 },
+          insColRight: { type: 'insertCols', sheet: activeSheetId, baseRev: collab.rev, index: c1 + 1, count: 1 },
+          delRows: { type: 'deleteRows', sheet: activeSheetId, baseRev: collab.rev, index: r0, count: r1 - r0 + 1 },
+          delCols: { type: 'deleteCols', sheet: activeSheetId, baseRev: collab.rev, index: c0, count: c1 - c0 + 1 },
+        };
+        collab.applyLocal(ops[action]);
+      },
+      exportXlsx: () => {
+        window.location.href = location.pathname + '/export.xlsx';
+      },
+      importXlsx: (file: File) => {
+        const body = new FormData();
+        body.append('file', file);
+        void fetch(location.pathname + '/import', { method: 'POST', body, credentials: 'same-origin' })
+          .then(async (res) => {
+            // On success the server broadcasts SHEET_RELOAD; the message handler reloads.
+            if (!res.ok) alert(await res.text());
+          })
+          .catch((err) => alert(String(err)));
+      },
     });
     formulaBar = createFormulaBar({
       readOnly: data.readonly,

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -296,7 +296,15 @@ export function startSheetEditor(root: HTMLElement): void {
         collab.applyLocal(ops[action]);
       },
       exportXlsx: () => {
-        window.location.href = location.pathname + '/export.xlsx';
+        // Anchor click, not location.href: Firefox treats the href navigation
+        // as an unload and kills the websocket even though the response is a
+        // download — the session would silently stop receiving broadcasts.
+        const a = document.createElement('a');
+        a.href = location.pathname + '/export.xlsx';
+        a.download = '';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
       },
       importXlsx: (file: File) => {
         const body = new FormData();
@@ -512,7 +520,12 @@ export function startSheetEditor(root: HTMLElement): void {
     });
   };
 
-  socket.once('connect', () => sendClientReady());
+  // on, not once: after a reconnect the server has a fresh connection that is
+  // not joined to the pad until CLIENT_READY is sent again — with `once` the
+  // session silently stops receiving broadcasts after any network blip. The
+  // SHEET_VARS reply re-runs initSheet with a fresh snapshot, which is exactly
+  // the SHEET_RELOAD semantic.
+  socket.on('connect', () => sendClientReady());
   socket.on('message', (msg: { type?: string; data?: any }) => {
     if (!msg || typeof msg !== 'object') return;
     if (msg.type === 'SHEET_VARS') {

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -25,8 +25,15 @@ interface SheetVarsData {
 }
 
 // Editor-level chrome (title bar above the ribbon, status bar below the tabs).
+// Excel window layout: the chrome is pinned to the viewport and only the grid
+// scrolls (sheet-grid-host is the scroll container; the freeze-pane sticky
+// offsets resolve against it).
 const CHROME_CSS = `
-.sheet-titlebar { display: flex; align-items: center; gap: 8px; height: 36px; padding: 0 12px; background: #107c41; color: #fff; font: 14px system-ui, sans-serif; }
+html, body { height: 100%; }
+body { margin: 0; overflow: hidden; }
+.sheet-app { display: flex; flex-direction: column; height: 100vh; }
+.sheet-grid-host { flex: 1; overflow: auto; min-height: 0; position: relative; }
+.sheet-titlebar { display: flex; align-items: center; gap: 8px; height: 36px; flex: none; padding: 0 12px; background: #107c41; color: #fff; font: 14px system-ui, sans-serif; }
 .sheet-titlebar svg { flex: none; display: block; }
 .sheet-title-name { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sheet-statusbar { display: flex; align-items: center; justify-content: space-between; height: 22px; padding: 0 10px; background: #f5f6f7; border-top: 1px solid #d4d8dd; font: 12px system-ui, sans-serif; color: #444; }
@@ -118,9 +125,10 @@ export function startSheetEditor(root: HTMLElement): void {
   const rawValue = (r: number, c: number): string =>
     collab?.display.getCell(activeSheetId, r, c)?.raw ?? '';
 
-  // Status-bar stats (Excel wording): Average/Sum over numeric raw values,
-  // Count = non-empty cells. Shown only for multi-cell selections with at
-  // least one numeric cell; empty otherwise.
+  // Status-bar stats (Excel wording): Average/Sum over numeric values —
+  // formula cells count with their COMPUTED value, like Excel. Count =
+  // non-empty cells. Shown only for multi-cell selections with at least one
+  // numeric cell; empty otherwise.
   let statsEl: HTMLElement | null = null;
   const updateStats = (): void => {
     if (!statsEl) return;
@@ -133,8 +141,9 @@ export function startSheetEditor(root: HTMLElement): void {
       const raw = rawValue(row, col);
       if (raw === '') continue;
       count++;
-      const n = Number(raw);
-      if (raw.trim() !== '' && Number.isFinite(n)) {
+      const value = raw.startsWith('=') ? engine.getValue(row, col).value : raw;
+      const n = Number(value);
+      if (value.trim() !== '' && Number.isFinite(n)) {
         sum += n;
         numCount++;
       }
@@ -233,6 +242,7 @@ export function startSheetEditor(root: HTMLElement): void {
       s.textContent = CHROME_CSS;
       document.head.appendChild(s);
     }
+    root.classList.add('sheet-app');
     const titlebar = document.createElement('div');
     titlebar.className = 'sheet-titlebar';
     titlebar.innerHTML = TITLE_ICON_SVG;
@@ -320,6 +330,7 @@ export function startSheetEditor(root: HTMLElement): void {
       },
     });
     const gridHost = document.createElement('div');
+    gridHost.className = 'sheet-grid-host';
     root.appendChild(toolbar);
     root.appendChild(formulaBar.el);
     root.appendChild(gridHost);

--- a/ui/src/js/sheet/sheetFormulaBar.ts
+++ b/ui/src/js/sheet/sheetFormulaBar.ts
@@ -13,15 +13,22 @@ export interface FormulaBarCallbacks {
 export interface FormulaBarHandle {
   el: HTMLElement;
   setActive: (ref: string, raw: string) => void;
+  // beginFormula focuses the input with `prefix)` and the caret right after
+  // the prefix — e.g. beginFormula('=SUM(') leaves the caret between the parens.
+  beginFormula: (prefix: string) => void;
 }
 
 const CSS = `
 .sheet-formula-bar { display: flex; align-items: stretch; gap: 6px; padding: 3px 4px; border-bottom: 1px solid #d4d8dd; background: #fff; font: 13px system-ui, sans-serif; position: relative; }
 .sheet-namebox { min-width: 72px; padding: 2px 6px; border: 1px solid #d4d8dd; background: #fff; text-align: center; align-self: center; border-radius: 3px; }
+.sheet-fx-sep { width: 1px; background: #d4d8dd; margin: 2px 0; }
+.sheet-fx-cancel, .sheet-fx-commit { align-self: center; width: 22px; height: 22px; padding: 0; border: none; border-radius: 2px; background: none; color: #8a8f95; font: 12px/1 system-ui, sans-serif; cursor: pointer; }
+.sheet-fx-cancel:hover, .sheet-fx-commit:hover { background: #e6f2ec; color: #107c41; }
+.sheet-fx-cancel:disabled, .sheet-fx-commit:disabled { opacity: .4; cursor: default; }
 .sheet-fx-label { align-self: center; font: italic 13px Georgia, 'Times New Roman', serif; color: #8a8f95; pointer-events: none; user-select: none; }
 .sheet-fx-input { flex: 1; padding: 2px 6px; border: 1px solid #d4d8dd; background: #fff; font: 13px/1.4 ui-monospace, monospace; outline: none; }
 .sheet-fx-input:focus { border-color: #107c41; }
-.sheet-fx-ac { position: absolute; top: 100%; left: 104px; z-index: 20; background: #fff; border: 1px solid #bbb; box-shadow: 0 2px 6px rgba(0,0,0,.15); min-width: 180px; max-height: 180px; overflow-y: auto; }
+.sheet-fx-ac { position: absolute; top: 100%; left: 152px; z-index: 20; background: #fff; border: 1px solid #bbb; box-shadow: 0 2px 6px rgba(0,0,0,.15); min-width: 180px; max-height: 180px; overflow-y: auto; }
 .sheet-fx-ac div { padding: 2px 8px; cursor: pointer; font: 12px/1.5 ui-monospace, monospace; }
 .sheet-fx-ac div.hl { background: #cfeede; }
 `;
@@ -40,6 +47,23 @@ export function createFormulaBar(cb: FormulaBarCallbacks): FormulaBarHandle {
   nameBox.className = 'sheet-namebox';
   nameBox.textContent = 'A1';
 
+  const sep = document.createElement('span');
+  sep.className = 'sheet-fx-sep';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'sheet-fx-cancel';
+  cancelBtn.title = 'Cancel';
+  cancelBtn.textContent = '✕';
+  cancelBtn.disabled = cb.readOnly;
+
+  const commitBtn = document.createElement('button');
+  commitBtn.type = 'button';
+  commitBtn.className = 'sheet-fx-commit';
+  commitBtn.title = 'Enter';
+  commitBtn.textContent = '✓';
+  commitBtn.disabled = cb.readOnly;
+
   const fx = document.createElement('span');
   fx.className = 'sheet-fx-label';
   fx.textContent = 'fx';
@@ -53,7 +77,7 @@ export function createFormulaBar(cb: FormulaBarCallbacks): FormulaBarHandle {
   ac.className = 'sheet-fx-ac';
   ac.style.display = 'none';
 
-  bar.append(nameBox, fx, input, ac);
+  bar.append(nameBox, sep, cancelBtn, commitBtn, fx, input, ac);
 
   let lastRaw = '';
   let acItems: string[] = [];
@@ -105,6 +129,13 @@ export function createFormulaBar(cb: FormulaBarCallbacks): FormulaBarHandle {
     else if (e.key === 'Escape') { e.preventDefault(); input.value = lastRaw; input.blur(); }
   });
 
+  // ✕/✓ mirror Escape/Enter in the input. mousedown is prevented so the click
+  // does not blur the input first (same trick as the autocomplete list).
+  cancelBtn.addEventListener('mousedown', (e) => e.preventDefault());
+  cancelBtn.addEventListener('click', () => { closeAc(); input.value = lastRaw; input.blur(); });
+  commitBtn.addEventListener('mousedown', (e) => e.preventDefault());
+  commitBtn.addEventListener('click', () => { closeAc(); cb.onCommit(input.value); input.blur(); });
+
   return {
     el: bar,
     setActive(ref: string, raw: string): void {
@@ -116,6 +147,12 @@ export function createFormulaBar(cb: FormulaBarCallbacks): FormulaBarHandle {
         lastRaw = raw;
         input.value = raw;
       }
+    },
+    beginFormula(prefix: string): void {
+      if (cb.readOnly) return;
+      input.focus();
+      input.value = prefix + ')';
+      input.setSelectionRange(prefix.length, prefix.length);
     },
   };
 }

--- a/ui/src/js/sheet/sheetFormulaBar.ts
+++ b/ui/src/js/sheet/sheetFormulaBar.ts
@@ -16,10 +16,12 @@ export interface FormulaBarHandle {
 }
 
 const CSS = `
-.sheet-formula-bar { display: flex; align-items: stretch; gap: 6px; padding: 3px 4px; border-bottom: 1px solid #d2d2d2; font: 13px system-ui, sans-serif; position: relative; }
-.sheet-namebox { min-width: 72px; padding: 2px 6px; border: 1px solid #ccc; background: #f8f9fa; text-align: center; align-self: center; border-radius: 3px; }
-.sheet-fx-input { flex: 1; padding: 2px 6px; border: 1px solid #ccc; font: 13px/1.4 ui-monospace, monospace; }
-.sheet-fx-ac { position: absolute; top: 100%; left: 84px; z-index: 20; background: #fff; border: 1px solid #bbb; box-shadow: 0 2px 6px rgba(0,0,0,.15); min-width: 180px; max-height: 180px; overflow-y: auto; }
+.sheet-formula-bar { display: flex; align-items: stretch; gap: 6px; padding: 3px 4px; border-bottom: 1px solid #d4d8dd; background: #fff; font: 13px system-ui, sans-serif; position: relative; }
+.sheet-namebox { min-width: 72px; padding: 2px 6px; border: 1px solid #d4d8dd; background: #fff; text-align: center; align-self: center; border-radius: 3px; }
+.sheet-fx-label { align-self: center; font: italic 13px Georgia, 'Times New Roman', serif; color: #8a8f95; pointer-events: none; user-select: none; }
+.sheet-fx-input { flex: 1; padding: 2px 6px; border: 1px solid #d4d8dd; background: #fff; font: 13px/1.4 ui-monospace, monospace; outline: none; }
+.sheet-fx-input:focus { border-color: #107c41; }
+.sheet-fx-ac { position: absolute; top: 100%; left: 104px; z-index: 20; background: #fff; border: 1px solid #bbb; box-shadow: 0 2px 6px rgba(0,0,0,.15); min-width: 180px; max-height: 180px; overflow-y: auto; }
 .sheet-fx-ac div { padding: 2px 8px; cursor: pointer; font: 12px/1.5 ui-monospace, monospace; }
 .sheet-fx-ac div.hl { background: #cfeede; }
 `;
@@ -38,6 +40,10 @@ export function createFormulaBar(cb: FormulaBarCallbacks): FormulaBarHandle {
   nameBox.className = 'sheet-namebox';
   nameBox.textContent = 'A1';
 
+  const fx = document.createElement('span');
+  fx.className = 'sheet-fx-label';
+  fx.textContent = 'fx';
+
   const input = document.createElement('input');
   input.className = 'sheet-fx-input';
   input.type = 'text';
@@ -47,7 +53,7 @@ export function createFormulaBar(cb: FormulaBarCallbacks): FormulaBarHandle {
   ac.className = 'sheet-fx-ac';
   ac.style.display = 'none';
 
-  bar.append(nameBox, input, ac);
+  bar.append(nameBox, fx, input, ac);
 
   let lastRaw = '';
   let acItems: string[] = [];

--- a/ui/src/js/sheet/sheetTabs.ts
+++ b/ui/src/js/sheet/sheetTabs.ts
@@ -15,10 +15,12 @@ export interface TabsCallbacks {
 
 const STYLE_ID = 'sheet-tabs-style';
 const CSS = `
-.sheet-tabs { display: flex; gap: 2px; align-items: center; padding: 4px 2px; font: 12px/1.4 system-ui, sans-serif; }
-.sheet-tabs button { border: 1px solid #d2d2d2; background: #f2f3f4; color: #485365; padding: 3px 12px; cursor: pointer; border-radius: 0 0 4px 4px; }
-.sheet-tabs button.sheet-tab-active { background: #fff; font-weight: 600; border-top-color: #fff; }
-.sheet-tabs button.sheet-tab-add { padding: 3px 8px; font-weight: 700; }
+.sheet-tabs { display: flex; gap: 1px; align-items: center; padding: 0 6px; font: 12px/1.4 system-ui, sans-serif; background: #f5f6f7; border-top: 1px solid #d4d8dd; }
+.sheet-tabs button { border: none; border-bottom: 2px solid transparent; background: #fff; color: #5f6b7a; padding: 5px 14px 3px; cursor: pointer; }
+.sheet-tabs button:hover { color: #107c41; }
+.sheet-tabs button.sheet-tab-active { background: #fff; color: #107c41; font-weight: 600; border-bottom-color: #107c41; }
+.sheet-tabs button.sheet-tab-add { width: 22px; height: 22px; padding: 0; margin-left: 4px; border: none; border-radius: 50%; background: none; color: #5f6b7a; font-weight: 700; font-size: 14px; line-height: 1; }
+.sheet-tabs button.sheet-tab-add:hover { background: #e6f2ec; color: #107c41; }
 `;
 
 export function createSheetTabs(cb: TabsCallbacks): { el: HTMLElement; refresh: () => void } {

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -1,6 +1,6 @@
-// Excel-style ribbon toolbar. Emits style-prop *changes* for the current
-// selection; the editor merges them onto each cell's existing props and sends
-// setStyle ops. Uses native inputs (no dependency).
+// Classic Microsoft-365-Excel-style ribbon toolbar. Emits style-prop *changes*
+// for the current selection; the editor merges them onto each cell's existing
+// props and sends setStyle ops. Uses native inputs and inline SVGs (no assets).
 
 export interface ToolbarCallbacks {
   getProps: (row: number, col: number) => Record<string, string>;
@@ -19,29 +19,68 @@ export interface ToolbarCallbacks {
   // Ribbon: workbook import/export (server round-trip).
   importXlsx?: (file: File) => void;
   exportXlsx?: () => void;
+  // Ribbon: clipboard + quick aggregation (wired by the editor).
+  clipboardAction?: (a: 'cut' | 'copy' | 'paste') => void;
+  autoSum?: () => void;
 }
 
 const CSS = `
-.sheet-toolbar { border-bottom: 1px solid #d4d8dd; background: #fff; font: 13px system-ui, sans-serif; }
+.sheet-toolbar { border-bottom: 1px solid #d4d8dd; background: #fff; font: 13px system-ui, sans-serif; user-select: none; }
 .sheet-toolbar[aria-disabled=true] { opacity: 0.5; pointer-events: none; }
-.sheet-ribbon-tabs { display: flex; gap: 2px; padding: 0 6px; background: #fff; border-bottom: 1px solid #e3e6ea; }
-.sheet-ribbon-tabs button { border: none; background: none; padding: 5px 12px 3px; font: 13px system-ui, sans-serif; color: #444; cursor: pointer; border-bottom: 2.5px solid transparent; }
-.sheet-ribbon-tabs button:hover { color: #107c41; }
-.sheet-ribbon-tabs button.on { color: #107c41; border-bottom-color: #107c41; font-weight: 600; }
-.sheet-ribbon-body { display: flex; align-items: stretch; min-height: 64px; padding: 4px 6px 2px; background: #f9fafb; overflow-x: auto; }
-.sheet-ribbon-group { display: flex; flex-direction: column; justify-content: space-between; padding: 2px 10px; border-right: 1px solid #e3e6ea; }
+.sheet-ribbon-tabs { display: flex; align-items: flex-end; gap: 2px; padding: 4px 8px 0; background: #fff; border-bottom: 1px solid #d4d8dd; position: relative; }
+.sheet-ribbon-tabs button { border: 1px solid transparent; border-bottom: none; background: none; padding: 5px 16px 6px; font: 13px system-ui, sans-serif; color: #5a5f66; cursor: pointer; border-radius: 4px 4px 0 0; margin-bottom: -1px; }
+.sheet-ribbon-tabs button:hover { color: #107c41; background: #e6f2ec; }
+.sheet-ribbon-tabs button.on { background: #f5f6f7; border-color: #d4d8dd; border-bottom: 1px solid #f5f6f7; color: #107c41; font-weight: 600; }
+.sheet-ribbon-tabs .sheet-file-tab, .sheet-ribbon-tabs .sheet-file-tab:hover { background: #107c41; color: #fff; font-weight: 600; border-radius: 4px 4px 0 0; }
+.sheet-ribbon-tabs .sheet-file-tab:hover { background: #0e6a38; }
+.sheet-file-wrap { position: relative; display: flex; }
+.sheet-file-menu { position: absolute; top: 100%; left: 0; z-index: 30; min-width: 170px; background: #fff; border: 1px solid #d4d8dd; box-shadow: 0 4px 10px rgba(0,0,0,0.15); padding: 4px 0; }
+.sheet-file-menu button { display: block; width: 100%; text-align: left; border: none; background: none; padding: 7px 14px; font: 13px system-ui, sans-serif; color: #333; cursor: pointer; }
+.sheet-file-menu button:hover { background: #e6f2ec; }
+.sheet-ribbon-body { display: flex; align-items: stretch; min-height: 66px; padding: 3px 6px 1px; background: #f5f6f7; overflow-x: auto; }
+.sheet-ribbon-group { display: flex; flex-direction: column; padding: 1px 8px; border-right: 1px solid #d9dde1; }
 .sheet-ribbon-group:last-child { border-right: none; }
+.sheet-ribbon-content { flex: 1; display: flex; gap: 3px; align-items: center; justify-content: center; }
+.sheet-ribbon-col { display: flex; flex-direction: column; gap: 2px; justify-content: center; }
 .sheet-ribbon-row { display: flex; gap: 3px; align-items: center; }
-.sheet-ribbon-label { font-size: 10.5px; color: #8a8f95; text-align: center; padding-top: 3px; }
-.sheet-ribbon-row button { height: 26px; min-width: 26px; padding: 0 6px; border: 1px solid transparent; border-radius: 3px; background: none; font: 13px system-ui, sans-serif; cursor: pointer; }
-.sheet-ribbon-row button:hover { background: #e6f2ec; border-color: #bcd8c9; }
-.sheet-ribbon-row button.on { background: #cce5d8; border-color: #9fccb4; }
-.sheet-ribbon-row select { height: 26px; border: 1px solid #c8cdd3; border-radius: 3px; background: #fff; font: 12px system-ui, sans-serif; cursor: pointer; }
-.sheet-ribbon-row input[type=color] { width: 26px; height: 26px; padding: 1px 2px; border: 1px solid transparent; border-radius: 3px; background: none; cursor: pointer; }
+.sheet-ribbon-label { font-size: 10.5px; color: #8a8f95; text-align: center; padding: 2px 2px 1px; }
+.sheet-ribbon-row button, .sheet-ribbon-big { border: 1px solid transparent; border-radius: 3px; background: none; font: 13px system-ui, sans-serif; color: #333; cursor: pointer; }
+.sheet-ribbon-row button { height: 24px; min-width: 26px; padding: 0 5px; display: inline-flex; align-items: center; justify-content: center; gap: 3px; }
+.sheet-ribbon-row button:hover, .sheet-ribbon-big:hover { background: #e6f2ec; border-color: #bcd8c9; }
+.sheet-ribbon-row button.on, .sheet-ribbon-big.on { background: #cce5d8; border-color: #9fccb4; }
+.sheet-ribbon-big { height: 62px; min-width: 48px; padding: 3px 6px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; font-size: 11px; }
+.sheet-ribbon-big .sheet-big-glyph { font-size: 22px; line-height: 26px; }
+.sheet-ribbon-row select { height: 22px; border: 1px solid #d4d8dd; border-radius: 2px; background: #fff; font: 12px system-ui, sans-serif; color: #333; cursor: pointer; }
+.sheet-ribbon-row select:hover { border-color: #bcd8c9; }
+.sheet-ribbon-row input[type=color] { width: 26px; height: 24px; padding: 1px 2px; border: 1px solid transparent; border-radius: 3px; background: none; cursor: pointer; }
 .sheet-ribbon-row input[type=color]:hover { background: #e6f2ec; border-color: #bcd8c9; }
 `;
 
 type TabName = 'Home' | 'Data' | 'View';
+
+// Inline 16x16 SVG icons (stroke = currentColor); scaled up for big buttons.
+const svg = (inner: string, size = 16): string =>
+  `<svg width="${size}" height="${size}" viewBox="0 0 16 16" fill="none" stroke="currentColor"` +
+  ` stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${inner}</svg>`;
+
+const IC = {
+  paste: '<rect x="3" y="3" width="10" height="11.5" rx="1"/><path d="M6 3V1.5h4V3"/><path d="M5.5 6.5h5M5.5 9h5M5.5 11.5h3"/>',
+  cut: '<circle cx="4" cy="12" r="1.8"/><circle cx="12" cy="12" r="1.8"/><path d="M5.3 10.6 11 2M10.7 10.6 5 2"/>',
+  copy: '<rect x="2.5" y="2.5" width="8" height="8" rx="1"/><path d="M5.5 13.5h7a1 1 0 0 0 1-1v-7"/>',
+  borders: '<rect x="2.5" y="2.5" width="11" height="11"/><path d="M8 2.5v11M2.5 8h11"/>',
+  alignLeft: '<path d="M2.5 4h11M2.5 7h7M2.5 10h11M2.5 13h7"/>',
+  alignCenter: '<path d="M2.5 4h11M4.5 7h7M2.5 10h11M4.5 13h7"/>',
+  alignRight: '<path d="M2.5 4h11M6.5 7h7M2.5 10h11M6.5 13h7"/>',
+  wrap: '<path d="M2.5 4h11M2.5 8h8.5a2.5 2.5 0 0 1 0 5H8M2.5 12h3"/><path d="M9.5 11.5 8 13l1.5 1.5"/>',
+  insRowAbove: '<rect x="2.5" y="10.5" width="11" height="3"/><path d="M8 8.5V3M5.5 5.5 8 3l2.5 2.5"/>',
+  insRowBelow: '<rect x="2.5" y="2.5" width="11" height="3"/><path d="M8 7.5V13M5.5 10.5 8 13l2.5-2.5"/>',
+  insColLeft: '<rect x="10.5" y="2.5" width="3" height="11"/><path d="M8.5 8H3M5.5 5.5 3 8l2.5 2.5"/>',
+  insColRight: '<rect x="2.5" y="2.5" width="3" height="11"/><path d="M7.5 8H13M10.5 5.5 13 8l-2.5 2.5"/>',
+  delRows: '<rect x="2.5" y="6.5" width="11" height="3"/><path d="M10.5 1.5l3 3M13.5 1.5l-3 3"/>',
+  delCols: '<rect x="6.5" y="2.5" width="3" height="11"/><path d="M11.5 6.5l3 3M14.5 6.5l-3 3"/>',
+  importFile: '<path d="M2.5 10.5v3h11v-3"/><path d="M8 2v7.5M4.5 6 8 9.5 11.5 6"/>',
+  exportFile: '<path d="M2.5 10.5v3h11v-3"/><path d="M8 9.5V2M4.5 5.5 8 2l3.5 3.5"/>',
+};
 
 export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   if (!document.getElementById('sheet-toolbar-style')) {
@@ -60,6 +99,51 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   body.className = 'sheet-ribbon-body';
   bar.append(tabsEl, body);
 
+  // Shared hidden .xlsx file input (File menu + Data tab use the same one).
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = '.xlsx';
+  fileInput.style.display = 'none';
+  fileInput.addEventListener('change', () => {
+    const f = fileInput.files?.[0];
+    if (f) cb.importXlsx?.(f);
+    fileInput.value = '';
+  });
+  bar.appendChild(fileInput);
+
+  // --- File tab: green, opens a dropdown menu instead of switching tabs ---
+  const fileWrap = document.createElement('div');
+  fileWrap.className = 'sheet-file-wrap';
+  const fileBtn = document.createElement('button');
+  fileBtn.className = 'sheet-file-tab';
+  fileBtn.textContent = 'File';
+  const fileMenu = document.createElement('div');
+  fileMenu.className = 'sheet-file-menu';
+  fileMenu.style.display = 'none';
+  const closeMenu = () => {
+    fileMenu.style.display = 'none';
+    document.removeEventListener('mousedown', onOutside, true);
+  };
+  const onOutside = (e: MouseEvent) => {
+    if (!fileWrap.contains(e.target as Node)) closeMenu();
+  };
+  fileBtn.addEventListener('click', () => {
+    if (fileMenu.style.display === 'none') {
+      fileMenu.style.display = '';
+      document.addEventListener('mousedown', onOutside, true);
+    } else closeMenu();
+  });
+  const fileMenuItem = (label: string, onClick: () => void) => {
+    const b = document.createElement('button');
+    b.textContent = label;
+    b.addEventListener('click', () => { closeMenu(); onClick(); });
+    fileMenu.appendChild(b);
+  };
+  if (cb.importXlsx) fileMenuItem('Import (.xlsx)', () => fileInput.click());
+  if (cb.exportXlsx) fileMenuItem('Export (.xlsx)', () => cb.exportXlsx?.());
+  fileWrap.append(fileBtn, fileMenu);
+  tabsEl.appendChild(fileWrap);
+
   const tabBtns = new Map<TabName, HTMLButtonElement>();
   const groups: { tab: TabName; el: HTMLElement }[] = [];
   const selectTab = (name: TabName) => {
@@ -74,66 +158,129 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
     tabsEl.appendChild(b);
   }
 
-  // Creates a group under a tab; returns the row to put controls into.
+  // Creates a group under a tab; returns its content container.
   const group = (tab: TabName, label: string): HTMLElement => {
     const g = document.createElement('div');
     g.className = 'sheet-ribbon-group';
-    const row = document.createElement('div');
-    row.className = 'sheet-ribbon-row';
+    const content = document.createElement('div');
+    content.className = 'sheet-ribbon-content';
     const lbl = document.createElement('div');
     lbl.className = 'sheet-ribbon-label';
     lbl.textContent = label;
-    g.append(row, lbl);
+    g.append(content, lbl);
     body.appendChild(g);
     groups.push({ tab, el: g });
-    return row;
+    return content;
+  };
+  const row = (parent: HTMLElement): HTMLElement => {
+    const r = document.createElement('div');
+    r.className = 'sheet-ribbon-row';
+    parent.appendChild(r);
+    return r;
+  };
+  const col = (parent: HTMLElement): HTMLElement => {
+    const c = document.createElement('div');
+    c.className = 'sheet-ribbon-col';
+    parent.appendChild(c);
+    return c;
   };
 
-  const btn = (row: HTMLElement, label: string, title: string, onClick: () => void): HTMLButtonElement => {
+  // Small icon-only (or short-text) button.
+  const btn = (parent: HTMLElement, content: { icon?: string; text?: string }, title: string, onClick: () => void): HTMLButtonElement => {
     const b = document.createElement('button');
-    b.textContent = label;
+    if (content.icon) b.innerHTML = svg(content.icon);
+    if (content.text) b.append(content.text);
     b.title = title;
     b.addEventListener('click', onClick);
-    row.appendChild(b);
+    parent.appendChild(b);
+    return b;
+  };
+  // Big Excel-style button: icon (or glyph) on top, label below.
+  const bigBtn = (parent: HTMLElement, icon: string, label: string, title: string, onClick: () => void): HTMLButtonElement => {
+    const b = document.createElement('button');
+    b.className = 'sheet-ribbon-big';
+    b.innerHTML = svg(icon, 28);
+    b.append(label);
+    b.title = title;
+    b.addEventListener('click', onClick);
+    parent.appendChild(b);
     return b;
   };
 
   const curProps = () => { const f = cb.focusCell(); return cb.getProps(f.row, f.col); };
-
-  // --- Home: Font ---
-  const font = group('Home', 'Font');
-  const toggleBtn = (label: string, key: string) => {
-    const b = btn(font, label, key, () => {
+  // Toggle a boolean style prop; `on` is derived from the focus cell's props.
+  const toggleBtn = (parent: HTMLElement, content: { icon?: string; text?: string }, title: string, key: string): HTMLButtonElement => {
+    const b = btn(parent, content, title, () => {
       const on = curProps()[key] === '1';
       cb.applyToSelection({ [key]: on ? '' : '1' });
     });
     b.dataset.key = key;
     return b;
   };
-  toggleBtn('B', 'bold').style.fontWeight = 'bold';
-  toggleBtn('I', 'italic').style.fontStyle = 'italic';
-  toggleBtn('U', 'underline').style.textDecoration = 'underline';
 
-  const color = document.createElement('input');
-  color.type = 'color'; color.title = 'Font color';
-  color.addEventListener('input', () => cb.applyToSelection({ color: color.value }));
-  font.appendChild(color);
+  // --- Home: Clipboard ---
+  if (cb.clipboardAction) {
+    const clip = group('Home', 'Clipboard');
+    bigBtn(clip, IC.paste, 'Paste', 'Paste', () => cb.clipboardAction?.('paste'));
+    const small = col(clip);
+    btn(small, { icon: IC.cut }, 'Cut', () => cb.clipboardAction?.('cut'));
+    btn(small, { icon: IC.copy }, 'Copy', () => cb.clipboardAction?.('copy'));
+  }
 
-  const bg = document.createElement('input');
-  bg.type = 'color'; bg.title = 'Fill color'; bg.value = '#ffffff';
-  bg.addEventListener('input', () => cb.applyToSelection({ bg: bg.value }));
-  font.appendChild(bg);
+  // --- Home: Font ---
+  const fontCol = col(group('Home', 'Font'));
+  const fontTop = row(fontCol);
+  const fontFamily = document.createElement('select');
+  fontFamily.className = 'sheet-font-family';
+  fontFamily.title = 'Font';
+  for (const f of ['Calibri', 'Arial', 'Times New Roman', 'Courier New', 'Georgia', 'Verdana']) {
+    const o = document.createElement('option');
+    o.value = f;
+    o.textContent = f;
+    fontFamily.appendChild(o);
+  }
+  fontFamily.addEventListener('change', () => cb.applyToSelection({ fontFamily: fontFamily.value }));
+  fontTop.appendChild(fontFamily);
+  const fontSize = document.createElement('select');
+  fontSize.className = 'sheet-font-size';
+  fontSize.title = 'Font size';
+  for (const n of [8, 9, 10, 11, 12, 14, 16, 18, 20, 24, 28, 36, 48]) {
+    const o = document.createElement('option');
+    o.value = String(n);
+    o.textContent = String(n);
+    fontSize.appendChild(o);
+  }
+  fontSize.value = '11';
+  fontSize.addEventListener('change', () => cb.applyToSelection({ fontSize: fontSize.value }));
+  fontTop.appendChild(fontSize);
 
-  btn(font, '▦', 'Borders', () => {
+  const fontRow = row(fontCol);
+  toggleBtn(fontRow, { text: 'B' }, 'bold', 'bold').style.fontWeight = 'bold';
+  toggleBtn(fontRow, { text: 'I' }, 'italic', 'italic').style.fontStyle = 'italic';
+  toggleBtn(fontRow, { text: 'U' }, 'underline', 'underline').style.textDecoration = 'underline';
+  btn(fontRow, { icon: IC.borders }, 'Borders', () => {
     const on = curProps().border === 'all';
     cb.applyToSelection({ border: on ? '' : 'all' });
   });
+  const bg = document.createElement('input');
+  bg.type = 'color';
+  bg.title = 'Fill color';
+  bg.value = '#ffffff';
+  bg.addEventListener('input', () => cb.applyToSelection({ bg: bg.value }));
+  fontRow.appendChild(bg);
+  const color = document.createElement('input');
+  color.type = 'color';
+  color.title = 'Font color';
+  color.addEventListener('input', () => cb.applyToSelection({ color: color.value }));
+  fontRow.appendChild(color);
 
   // --- Home: Alignment ---
   const alignRow = group('Home', 'Alignment');
+  const alignIcons = { left: IC.alignLeft, center: IC.alignCenter, right: IC.alignRight } as const;
   for (const a of ['left', 'center', 'right'] as const) {
-    btn(alignRow, { left: '⯇', center: '☰', right: '⯈' }[a], `Align ${a}`, () => cb.applyToSelection({ align: a }));
+    btn(alignRow, { icon: alignIcons[a] }, `Align ${a}`, () => cb.applyToSelection({ align: a }));
   }
+  toggleBtn(alignRow, { icon: IC.wrap }, 'Wrap text', 'wrap');
 
   // --- Home: Number ---
   const numRow = group('Home', 'Number');
@@ -147,27 +294,45 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
 
   // --- Home: Cells ---
   if (cb.structural) {
-    const cells = group('Home', 'Cells');
+    const cells = col(group('Home', 'Cells'));
     const acts = [
-      ['insRowAbove', '⤒ Row', 'Insert row above'],
-      ['insRowBelow', '⤓ Row', 'Insert row below'],
-      ['insColLeft', '⇤ Col', 'Insert column left'],
-      ['insColRight', '⇥ Col', 'Insert column right'],
-      ['delRows', '✕ Rows', 'Delete selected rows'],
-      ['delCols', '✕ Cols', 'Delete selected columns'],
+      ['insRowAbove', IC.insRowAbove, 'Insert row above'],
+      ['insRowBelow', IC.insRowBelow, 'Insert row below'],
+      ['insColLeft', IC.insColLeft, 'Insert column left'],
+      ['insColRight', IC.insColRight, 'Insert column right'],
+      ['delRows', IC.delRows, 'Delete selected rows'],
+      ['delCols', IC.delCols, 'Delete selected columns'],
     ] as const;
-    for (const [act, label, title] of acts) {
-      btn(cells, label, title, () => cb.structural?.(act)).dataset.act = act;
+    const r1 = row(cells);
+    const r2 = row(cells);
+    acts.forEach(([act, icon, title], i) => {
+      btn(i < 3 ? r1 : r2, { icon }, title, () => cb.structural?.(act)).dataset.act = act;
+    });
+  }
+
+  // --- Home: Editing ---
+  if (cb.autoSum) {
+    const editing = group('Home', 'Editing');
+    btn(editing, { text: 'Σ' }, 'AutoSum', () => cb.autoSum?.());
+  }
+
+  // --- Data: Get & Transform ---
+  if (cb.importXlsx || cb.exportXlsx) {
+    const gt = group('Data', 'Get & Transform');
+    if (cb.importXlsx) {
+      bigBtn(gt, IC.importFile, 'Import', 'Import .xlsx (replaces this sheet)', () => fileInput.click());
+    }
+    if (cb.exportXlsx) {
+      bigBtn(gt, IC.exportFile, 'Export', 'Export as .xlsx', () => cb.exportXlsx?.());
     }
   }
 
-  // --- Data: Sort ---
-  const sort = group('Data', 'Sort');
-  btn(sort, 'A→Z', 'Sort selection ascending by the focused column', () => cb.sortSelection?.(true));
-  btn(sort, 'Z→A', 'Sort selection descending by the focused column', () => cb.sortSelection?.(false));
-
-  // --- Data: Filter ---
-  const filterRow = group('Data', 'Filter');
+  // --- Data: Sort & Filter ---
+  const sf = col(group('Data', 'Sort & Filter'));
+  const sortRow = row(sf);
+  btn(sortRow, { text: 'A→Z' }, 'Sort selection ascending by the focused column', () => cb.sortSelection?.(true));
+  btn(sortRow, { text: 'Z→A' }, 'Sort selection descending by the focused column', () => cb.sortSelection?.(false));
+  const filterRow = row(sf);
   const filter = document.createElement('select');
   filter.title = 'Filter rows by the focused column';
   const fill = () => {
@@ -189,42 +354,30 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   filter.addEventListener('change', () => cb.applyFilter?.(filter.value === '' ? null : filter.value));
   filterRow.appendChild(filter);
 
-  // --- Data: Workbook ---
-  if (cb.importXlsx || cb.exportXlsx) {
-    const wb = group('Data', 'Workbook');
-    if (cb.importXlsx) {
-      const file = document.createElement('input');
-      file.type = 'file';
-      file.accept = '.xlsx';
-      file.style.display = 'none';
-      file.addEventListener('change', () => {
-        const f = file.files?.[0];
-        if (f) cb.importXlsx?.(f);
-        file.value = '';
-      });
-      wb.appendChild(file);
-      btn(wb, '⬆ Import', 'Import an .xlsx workbook', () => file.click());
-    }
-    if (cb.exportXlsx) {
-      btn(wb, '⬇ Export', 'Export as .xlsx workbook', () => cb.exportXlsx?.());
-    }
-  }
-
   // --- View: Freeze panes ---
   const freeze = group('View', 'Freeze panes');
   const mkFreeze = (label: string, kind: 'row' | 'col', title: string) => {
-    const sync = (b: HTMLButtonElement) => {
+    const b = document.createElement('button');
+    b.className = 'sheet-ribbon-big';
+    // Glyph span on top + text node below; textContent stays exactly '❄ Row'.
+    const glyph = document.createElement('span');
+    glyph.className = 'sheet-big-glyph';
+    glyph.textContent = '❄';
+    b.append(glyph, ` ${label}`);
+    b.title = title;
+    const sync = () => {
       const fz = cb.frozenState?.() ?? { rows: 0, cols: 0 };
       b.classList.toggle('on', kind === 'row' ? fz.rows > 0 : fz.cols > 0);
     };
-    const b = btn(freeze, label, title, () => {
+    b.addEventListener('click', () => {
       cb.toggleFreeze?.(kind);
-      sync(b);
+      sync();
     });
-    sync(b);
+    sync();
+    freeze.appendChild(b);
   };
-  mkFreeze('❄ Row', 'row', 'Freeze first row');
-  mkFreeze('❄ Col', 'col', 'Freeze first column');
+  mkFreeze('Row', 'row', 'Freeze first row');
+  mkFreeze('Col', 'col', 'Freeze first column');
 
   selectTab('Home');
   return bar;

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -1,4 +1,4 @@
-// Minimal formatting toolbar. Emits style-prop *changes* for the current
+// Excel-style ribbon toolbar. Emits style-prop *changes* for the current
 // selection; the editor merges them onto each cell's existing props and sends
 // setStyle ops. Uses native inputs (no dependency).
 
@@ -14,15 +14,34 @@ export interface ToolbarCallbacks {
   // Filter on the focus column: values() fills the dropdown lazily, apply(null) clears.
   filterValues?: () => string[];
   applyFilter?: (value: string | null) => void;
+  // Ribbon: row/col structure relative to the selection.
+  structural?: (action: 'insRowAbove' | 'insRowBelow' | 'insColLeft' | 'insColRight' | 'delRows' | 'delCols') => void;
+  // Ribbon: workbook import/export (server round-trip).
+  importXlsx?: (file: File) => void;
+  exportXlsx?: () => void;
 }
 
 const CSS = `
-.sheet-toolbar { display: flex; gap: 4px; align-items: center; padding: 4px; border-bottom: 1px solid #d2d2d2; font: 13px system-ui, sans-serif; flex-wrap: wrap; }
-.sheet-toolbar button, .sheet-toolbar select { height: 24px; min-width: 24px; cursor: pointer; }
-.sheet-toolbar button.on { background: #cfeede; }
-.sheet-toolbar input[type=color] { width: 26px; height: 24px; padding: 0; border: 1px solid #ccc; }
+.sheet-toolbar { border-bottom: 1px solid #d4d8dd; background: #fff; font: 13px system-ui, sans-serif; }
 .sheet-toolbar[aria-disabled=true] { opacity: 0.5; pointer-events: none; }
+.sheet-ribbon-tabs { display: flex; gap: 2px; padding: 0 6px; background: #fff; border-bottom: 1px solid #e3e6ea; }
+.sheet-ribbon-tabs button { border: none; background: none; padding: 5px 12px 3px; font: 13px system-ui, sans-serif; color: #444; cursor: pointer; border-bottom: 2.5px solid transparent; }
+.sheet-ribbon-tabs button:hover { color: #107c41; }
+.sheet-ribbon-tabs button.on { color: #107c41; border-bottom-color: #107c41; font-weight: 600; }
+.sheet-ribbon-body { display: flex; align-items: stretch; min-height: 64px; padding: 4px 6px 2px; background: #f9fafb; overflow-x: auto; }
+.sheet-ribbon-group { display: flex; flex-direction: column; justify-content: space-between; padding: 2px 10px; border-right: 1px solid #e3e6ea; }
+.sheet-ribbon-group:last-child { border-right: none; }
+.sheet-ribbon-row { display: flex; gap: 3px; align-items: center; }
+.sheet-ribbon-label { font-size: 10.5px; color: #8a8f95; text-align: center; padding-top: 3px; }
+.sheet-ribbon-row button { height: 26px; min-width: 26px; padding: 0 6px; border: 1px solid transparent; border-radius: 3px; background: none; font: 13px system-ui, sans-serif; cursor: pointer; }
+.sheet-ribbon-row button:hover { background: #e6f2ec; border-color: #bcd8c9; }
+.sheet-ribbon-row button.on { background: #cce5d8; border-color: #9fccb4; }
+.sheet-ribbon-row select { height: 26px; border: 1px solid #c8cdd3; border-radius: 3px; background: #fff; font: 12px system-ui, sans-serif; cursor: pointer; }
+.sheet-ribbon-row input[type=color] { width: 26px; height: 26px; padding: 1px 2px; border: 1px solid transparent; border-radius: 3px; background: none; cursor: pointer; }
+.sheet-ribbon-row input[type=color]:hover { background: #e6f2ec; border-color: #bcd8c9; }
 `;
+
+type TabName = 'Home' | 'Data' | 'View';
 
 export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   if (!document.getElementById('sheet-toolbar-style')) {
@@ -35,18 +54,60 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   bar.className = 'sheet-toolbar';
   if (cb.readOnly) bar.setAttribute('aria-disabled', 'true');
 
-  const curProps = () => { const f = cb.focusCell(); return cb.getProps(f.row, f.col); };
+  const tabsEl = document.createElement('div');
+  tabsEl.className = 'sheet-ribbon-tabs';
+  const body = document.createElement('div');
+  body.className = 'sheet-ribbon-body';
+  bar.append(tabsEl, body);
 
-  const toggleBtn = (label: string, key: string) => {
+  const tabBtns = new Map<TabName, HTMLButtonElement>();
+  const groups: { tab: TabName; el: HTMLElement }[] = [];
+  const selectTab = (name: TabName) => {
+    for (const [n, b] of tabBtns) b.classList.toggle('on', n === name);
+    for (const g of groups) g.el.style.display = g.tab === name ? '' : 'none';
+  };
+  for (const name of ['Home', 'Data', 'View'] as TabName[]) {
+    const b = document.createElement('button');
+    b.textContent = name;
+    b.addEventListener('click', () => selectTab(name));
+    tabBtns.set(name, b);
+    tabsEl.appendChild(b);
+  }
+
+  // Creates a group under a tab; returns the row to put controls into.
+  const group = (tab: TabName, label: string): HTMLElement => {
+    const g = document.createElement('div');
+    g.className = 'sheet-ribbon-group';
+    const row = document.createElement('div');
+    row.className = 'sheet-ribbon-row';
+    const lbl = document.createElement('div');
+    lbl.className = 'sheet-ribbon-label';
+    lbl.textContent = label;
+    g.append(row, lbl);
+    body.appendChild(g);
+    groups.push({ tab, el: g });
+    return row;
+  };
+
+  const btn = (row: HTMLElement, label: string, title: string, onClick: () => void): HTMLButtonElement => {
     const b = document.createElement('button');
     b.textContent = label;
-    b.title = key;
-    b.dataset.key = key;
-    b.addEventListener('click', () => {
+    b.title = title;
+    b.addEventListener('click', onClick);
+    row.appendChild(b);
+    return b;
+  };
+
+  const curProps = () => { const f = cb.focusCell(); return cb.getProps(f.row, f.col); };
+
+  // --- Home: Font ---
+  const font = group('Home', 'Font');
+  const toggleBtn = (label: string, key: string) => {
+    const b = btn(font, label, key, () => {
       const on = curProps()[key] === '1';
       cb.applyToSelection({ [key]: on ? '' : '1' });
     });
-    bar.appendChild(b);
+    b.dataset.key = key;
     return b;
   };
   toggleBtn('B', 'bold').style.fontWeight = 'bold';
@@ -56,90 +117,115 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   const color = document.createElement('input');
   color.type = 'color'; color.title = 'Font color';
   color.addEventListener('input', () => cb.applyToSelection({ color: color.value }));
-  bar.appendChild(color);
+  font.appendChild(color);
 
   const bg = document.createElement('input');
   bg.type = 'color'; bg.title = 'Fill color'; bg.value = '#ffffff';
   bg.addEventListener('input', () => cb.applyToSelection({ bg: bg.value }));
-  bar.appendChild(bg);
+  font.appendChild(bg);
 
-  const align = document.createElement('select');
-  align.title = 'Align';
-  for (const a of ['left', 'center', 'right']) {
-    const o = document.createElement('option'); o.value = a; o.textContent = a; align.appendChild(o);
-  }
-  align.addEventListener('change', () => cb.applyToSelection({ align: align.value }));
-  bar.appendChild(align);
-
-  const border = document.createElement('button');
-  border.textContent = '▦'; border.title = 'Borders';
-  border.addEventListener('click', () => {
+  btn(font, '▦', 'Borders', () => {
     const on = curProps().border === 'all';
     cb.applyToSelection({ border: on ? '' : 'all' });
   });
-  bar.appendChild(border);
 
+  // --- Home: Alignment ---
+  const alignRow = group('Home', 'Alignment');
+  for (const a of ['left', 'center', 'right'] as const) {
+    btn(alignRow, { left: '⯇', center: '☰', right: '⯈' }[a], `Align ${a}`, () => cb.applyToSelection({ align: a }));
+  }
+
+  // --- Home: Number ---
+  const numRow = group('Home', 'Number');
   const numFmt = document.createElement('select');
   numFmt.title = 'Number format';
   for (const [v, label] of [['general', 'General'], ['number:2', 'Number'], ['currency:2', 'Currency'], ['percent:0', 'Percent'], ['date', 'Date'], ['text', 'Text']] as const) {
     const o = document.createElement('option'); o.value = v; o.textContent = label; numFmt.appendChild(o);
   }
   numFmt.addEventListener('change', () => cb.applyToSelection({ numFmt: numFmt.value }));
-  bar.appendChild(numFmt);
+  numRow.appendChild(numFmt);
 
-  if (cb.sortSelection) {
-    const az = document.createElement('button');
-    az.textContent = 'A→Z';
-    az.title = 'Sort selection ascending by the focused column';
-    az.addEventListener('click', () => cb.sortSelection?.(true));
-    bar.appendChild(az);
-    const za = document.createElement('button');
-    za.textContent = 'Z→A';
-    za.title = 'Sort selection descending by the focused column';
-    za.addEventListener('click', () => cb.sortSelection?.(false));
-    bar.appendChild(za);
+  // --- Home: Cells ---
+  if (cb.structural) {
+    const cells = group('Home', 'Cells');
+    const acts = [
+      ['insRowAbove', '⤒ Row', 'Insert row above'],
+      ['insRowBelow', '⤓ Row', 'Insert row below'],
+      ['insColLeft', '⇤ Col', 'Insert column left'],
+      ['insColRight', '⇥ Col', 'Insert column right'],
+      ['delRows', '✕ Rows', 'Delete selected rows'],
+      ['delCols', '✕ Cols', 'Delete selected columns'],
+    ] as const;
+    for (const [act, label, title] of acts) {
+      btn(cells, label, title, () => cb.structural?.(act)).dataset.act = act;
+    }
   }
 
-  if (cb.toggleFreeze) {
-    const mk = (label: string, kind: 'row' | 'col', title: string) => {
-      const b = document.createElement('button');
-      b.textContent = label;
-      b.title = title;
-      b.addEventListener('click', () => {
-        cb.toggleFreeze?.(kind);
-        const fz = cb.frozenState?.() ?? { rows: 0, cols: 0 };
-        b.classList.toggle('on', kind === 'row' ? fz.rows > 0 : fz.cols > 0);
+  // --- Data: Sort ---
+  const sort = group('Data', 'Sort');
+  btn(sort, 'A→Z', 'Sort selection ascending by the focused column', () => cb.sortSelection?.(true));
+  btn(sort, 'Z→A', 'Sort selection descending by the focused column', () => cb.sortSelection?.(false));
+
+  // --- Data: Filter ---
+  const filterRow = group('Data', 'Filter');
+  const filter = document.createElement('select');
+  filter.title = 'Filter rows by the focused column';
+  const fill = () => {
+    filter.innerHTML = '';
+    const all = document.createElement('option');
+    all.value = '';
+    all.textContent = '▼ Filter: (all)';
+    filter.appendChild(all);
+    for (const v of cb.filterValues?.() ?? []) {
+      const o = document.createElement('option');
+      o.value = v;
+      o.textContent = v;
+      filter.appendChild(o);
+    }
+  };
+  fill();
+  filter.addEventListener('mousedown', fill); // repopulate lazily on open
+  filter.addEventListener('focus', fill); // and for keyboard users
+  filter.addEventListener('change', () => cb.applyFilter?.(filter.value === '' ? null : filter.value));
+  filterRow.appendChild(filter);
+
+  // --- Data: Workbook ---
+  if (cb.importXlsx || cb.exportXlsx) {
+    const wb = group('Data', 'Workbook');
+    if (cb.importXlsx) {
+      const file = document.createElement('input');
+      file.type = 'file';
+      file.accept = '.xlsx';
+      file.style.display = 'none';
+      file.addEventListener('change', () => {
+        const f = file.files?.[0];
+        if (f) cb.importXlsx?.(f);
+        file.value = '';
       });
+      wb.appendChild(file);
+      btn(wb, '⬆ Import', 'Import an .xlsx workbook', () => file.click());
+    }
+    if (cb.exportXlsx) {
+      btn(wb, '⬇ Export', 'Export as .xlsx workbook', () => cb.exportXlsx?.());
+    }
+  }
+
+  // --- View: Freeze panes ---
+  const freeze = group('View', 'Freeze panes');
+  const mkFreeze = (label: string, kind: 'row' | 'col', title: string) => {
+    const sync = (b: HTMLButtonElement) => {
       const fz = cb.frozenState?.() ?? { rows: 0, cols: 0 };
       b.classList.toggle('on', kind === 'row' ? fz.rows > 0 : fz.cols > 0);
-      bar.appendChild(b);
     };
-    mk('❄R', 'row', 'Freeze first row');
-    mk('❄C', 'col', 'Freeze first column');
-  }
+    const b = btn(freeze, label, title, () => {
+      cb.toggleFreeze?.(kind);
+      sync(b);
+    });
+    sync(b);
+  };
+  mkFreeze('❄ Row', 'row', 'Freeze first row');
+  mkFreeze('❄ Col', 'col', 'Freeze first column');
 
-  if (cb.filterValues && cb.applyFilter) {
-    const filter = document.createElement('select');
-    filter.title = 'Filter rows by the focused column';
-    const fill = () => {
-      filter.innerHTML = '';
-      const all = document.createElement('option');
-      all.value = '';
-      all.textContent = '▼ Filter: (all)';
-      filter.appendChild(all);
-      for (const v of cb.filterValues?.() ?? []) {
-        const o = document.createElement('option');
-        o.value = v;
-        o.textContent = v;
-        filter.appendChild(o);
-      }
-    };
-    fill();
-    filter.addEventListener('mousedown', fill); // repopulate lazily on open
-    filter.addEventListener('focus', fill); // and for keyboard users
-    filter.addEventListener('change', () => cb.applyFilter?.(filter.value === '' ? null : filter.value));
-    bar.appendChild(filter);
-  }
-
+  selectTab('Home');
   return bar;
 }

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -49,6 +49,11 @@ const CSS = `
 .sheet-grid { border-collapse: separate; border-spacing: 0; border-top: 1px solid #d4d4d4; border-left: 1px solid #d4d4d4; font: 13px/1.4 system-ui, sans-serif; }
 .sheet-grid th, .sheet-grid td { border-right: 1px solid #d4d4d4; border-bottom: 1px solid #d4d4d4; min-width: 80px; height: 22px; padding: 2px 6px; }
 .sheet-grid th { background: #f5f6f7; color: #5f6b7a; font-weight: 600; text-align: center; position: relative; }
+/* Excel keeps headers visible while the grid scrolls: column letters stick to
+   the top, row numbers to the left of the scroll container (sheet-grid-host). */
+.sheet-grid thead th { position: sticky; top: 0; z-index: 8; }
+.sheet-grid thead th:first-child { left: 0; z-index: 9; }
+.sheet-grid tbody th { position: sticky; left: 0; z-index: 4; }
 .sheet-grid th.sheet-head-hl { background: #e6f2ec; color: #0f6b3a; }
 .sheet-grid thead th.sheet-head-hl { box-shadow: inset 0 -2px 0 #107c41; }
 .sheet-grid tbody th.sheet-head-hl { box-shadow: inset -2px 0 0 #107c41; }

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -46,24 +46,27 @@ const STYLE_ID = 'sheet-grid-style';
 // collapsed borders while a frozen row/col sticks. Right/bottom-only borders
 // keep the 1px grid look without doubling.
 const CSS = `
-.sheet-grid { border-collapse: separate; border-spacing: 0; border-top: 1px solid #d2d2d2; border-left: 1px solid #d2d2d2; font: 13px/1.4 system-ui, sans-serif; }
-.sheet-grid th, .sheet-grid td { border-right: 1px solid #d2d2d2; border-bottom: 1px solid #d2d2d2; min-width: 80px; height: 22px; padding: 2px 6px; }
-.sheet-grid th { background: #f2f3f4; color: #485365; font-weight: 600; text-align: center; position: relative; }
-.sheet-grid td { outline: none; position: relative; background: #fff; }
+.sheet-grid { border-collapse: separate; border-spacing: 0; border-top: 1px solid #d4d4d4; border-left: 1px solid #d4d4d4; font: 13px/1.4 system-ui, sans-serif; }
+.sheet-grid th, .sheet-grid td { border-right: 1px solid #d4d4d4; border-bottom: 1px solid #d4d4d4; min-width: 80px; height: 22px; padding: 2px 6px; }
+.sheet-grid th { background: #f5f6f7; color: #5f6b7a; font-weight: 600; text-align: center; position: relative; }
+.sheet-grid th.sheet-head-hl { background: #e6f2ec; color: #0f6b3a; }
+.sheet-grid thead th.sheet-head-hl { box-shadow: inset 0 -2px 0 #107c41; }
+.sheet-grid tbody th.sheet-head-hl { box-shadow: inset -2px 0 0 #107c41; }
+.sheet-grid td { outline: none; position: relative; background: #fff; white-space: nowrap; overflow: hidden; }
 .sheet-resizer-col { position: absolute; top: 0; right: -3px; width: 6px; height: 100%; cursor: col-resize; z-index: 9; }
 .sheet-resizer-row { position: absolute; left: 0; bottom: -3px; height: 6px; width: 100%; cursor: row-resize; z-index: 9; }
 .sheet-grid.sheet-frozen-r thead th { position: sticky; top: 0; z-index: 8; }
 .sheet-grid.sheet-frozen-r tbody tr:first-child th, .sheet-grid.sheet-frozen-r tbody tr:first-child td { position: sticky; top: var(--fr-top, 24px); z-index: 7; }
 .sheet-grid.sheet-frozen-c tbody th, .sheet-grid.sheet-frozen-c thead th:first-child { position: sticky; left: 0; z-index: 8; }
 .sheet-grid.sheet-frozen-c thead th:nth-child(2), .sheet-grid.sheet-frozen-c tbody td:first-of-type { position: sticky; left: var(--fc-left, 40px); z-index: 6; }
-.sheet-grid td:focus { box-shadow: inset 0 0 0 2px #64d29b; }
+.sheet-grid td:focus { box-shadow: inset 0 0 0 2px #107c41; overflow: visible; z-index: 3; }
 .sheet-remote-tag { position: absolute; top: -15px; left: -1px; font: 10px/14px system-ui, sans-serif; padding: 0 4px; color: #fff; border-radius: 3px 3px 3px 0; white-space: nowrap; z-index: 5; pointer-events: none; }
 .sheet-remote-tag::after { content: attr(data-label); }
-.sheet-grid td.sheet-sel { background: rgba(100, 210, 155, 0.15); }
-.sheet-grid td.sheet-sel-focus { box-shadow: inset 0 0 0 2px #2f9e6b; }
+.sheet-grid td.sheet-sel { background: rgba(16, 124, 65, 0.10); }
+.sheet-grid td.sheet-sel-focus { box-shadow: inset 0 0 0 2px #107c41; }
 .sheet-grid td.sheet-remote-sel { box-shadow: inset 0 0 0 2px var(--rsel, #888); }
-.sheet-fill-handle { position: absolute; width: 8px; height: 8px; background: #2f9e6b; border: 1px solid #fff; cursor: crosshair; z-index: 6; }
-.sheet-grid td.sheet-fill-target { box-shadow: inset 0 0 0 1px #2f9e6b; }
+.sheet-fill-handle { position: absolute; width: 8px; height: 8px; background: #107c41; border: 1px solid #fff; cursor: crosshair; z-index: 6; }
+.sheet-grid td.sheet-fill-target { box-shadow: inset 0 0 0 1px #107c41; }
 .sheet-grid td.sheet-cell-error { color: #c0392b; }
 `;
 
@@ -347,6 +350,7 @@ export class DomSheetView {
   render(): void {
     for (const td of this.decorated) {
       td.style.boxShadow = '';
+      td.style.overflow = '';
       td.classList.remove('sheet-remote-sel', 'sheet-fill-target');
       td.style.removeProperty('--rsel');
       td.querySelector('.sheet-remote-tag')?.remove();
@@ -380,7 +384,14 @@ export class DomSheetView {
         td.style.background = '';
         td.style.textAlign = '';
         td.style.border = '';
+        td.style.fontFamily = '';
+        td.style.fontSize = '';
+        // whiteSpace: normal (wrap) overrides the CSS nowrap default via inline style.
+        td.style.whiteSpace = '';
         if (this.opts.styleOf) {
+          // NOTE: fontFamily/fontSize/whiteSpace are added to CellCss in a
+          // parallel styleCss.ts change; until it lands tsc flags these three
+          // property accesses as unknown (expected).
           const css = styleToCss(this.opts.styleOf(r, c));
           if (css.fontWeight) td.style.fontWeight = css.fontWeight;
           if (css.fontStyle) td.style.fontStyle = css.fontStyle;
@@ -389,6 +400,9 @@ export class DomSheetView {
           if (css.background) td.style.background = css.background;
           if (css.textAlign) td.style.textAlign = css.textAlign;
           if (css.border) td.style.border = css.border;
+          if (css.fontFamily) td.style.fontFamily = css.fontFamily;
+          if (css.fontSize) td.style.fontSize = css.fontSize;
+          if (css.whiteSpace) td.style.whiteSpace = css.whiteSpace;
         }
         const err = this.opts.errorOf?.(r, c);
         td.classList.toggle('sheet-cell-error', !!err);
@@ -403,6 +417,9 @@ export class DomSheetView {
           tag.setAttribute('data-label', deco.name || 'anon');
           tag.style.background = deco.color;
           td.appendChild(tag);
+          // The tag sits above the cell (top: -15px) — lift the td's
+          // overflow: hidden default so it is not clipped (reset on cleanup).
+          td.style.overflow = 'visible';
           this.decorated.add(td);
         }
       }
@@ -419,6 +436,10 @@ export class DomSheetView {
         );
       }
     }
+    // Excel-style header highlight for the selected range.
+    const selN = normalize(this.selection);
+    this.colHeads.forEach((th, c) => th.classList.toggle('sheet-head-hl', c >= selN.c0 && c <= selN.c1));
+    this.rowHeads.forEach((th, r) => th.classList.toggle('sheet-head-hl', r >= selN.r0 && r <= selN.r1));
     // remote selections (outline only, multi-cell)
     for (const rs of this.remoteSel) {
       const { r0, c0, r1, c1 } = normalize(rs.sel);

--- a/ui/src/js/sheet/styleCss.test.ts
+++ b/ui/src/js/sheet/styleCss.test.ts
@@ -11,10 +11,21 @@ describe('styleToCss', () => {
     expect(styleToCss({ border: 'all' }).border).toBe('1px solid #333');
     expect(styleToCss({})).toEqual({});
   });
+  it('maps fontFamily, fontSize, and wrap', () => {
+    expect(styleToCss({ fontFamily: 'Calibri', fontSize: '11', wrap: '1' }))
+      .toEqual({ fontFamily: 'Calibri', fontSize: '11pt', whiteSpace: 'normal' });
+    expect(styleToCss({ fontSize: '6' }).fontSize).toBe('6pt');
+    expect(styleToCss({ fontSize: '96' }).fontSize).toBe('96pt');
+  });
   it('ignores non-allowlisted values (defense against CSS injection)', () => {
     expect(styleToCss({ bg: 'url(https://evil.example/x)' })).toEqual({});
     expect(styleToCss({ color: 'red' })).toEqual({});
     expect(styleToCss({ align: 'justify; background: url(https://x)' })).toEqual({});
+    expect(styleToCss({ fontFamily: 'Hack;background:url(x)' })).toEqual({});
+    expect(styleToCss({ fontSize: '999' })).toEqual({});
+    expect(styleToCss({ fontSize: '0' })).toEqual({});
+    expect(styleToCss({ fontSize: '012' })).toEqual({});
+    expect(styleToCss({ wrap: 'yes' })).toEqual({});
   });
 });
 

--- a/ui/src/js/sheet/styleCss.ts
+++ b/ui/src/js/sheet/styleCss.ts
@@ -5,12 +5,15 @@
 export type CellCss = {
   fontWeight?: string; fontStyle?: string; textDecoration?: string;
   color?: string; background?: string; textAlign?: string; border?: string;
+  fontFamily?: string; fontSize?: string; whiteSpace?: string;
 };
 
 // Defense in depth: props are validated server-side (lib/sheet/op.go), but a
 // value like bg: "url(...)" must never reach td.style even if bad data slips in.
 const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 const ALIGNS = new Set(['left', 'center', 'right']);
+const FONT_FAMILIES = new Set(['Calibri', 'Arial', 'Times New Roman', 'Courier New', 'Georgia', 'Verdana']);
+const FONT_SIZE = /^[1-9]\d?$/; // 6..96, range-checked below
 
 export function styleToCss(props: Record<string, string>): CellCss {
   const css: CellCss = {};
@@ -21,6 +24,12 @@ export function styleToCss(props: Record<string, string>): CellCss {
   if (props.bg && HEX_COLOR.test(props.bg)) css.background = props.bg;
   if (props.align && ALIGNS.has(props.align)) css.textAlign = props.align;
   if (props.border === 'all') css.border = '1px solid #333';
+  if (props.fontFamily && FONT_FAMILIES.has(props.fontFamily)) css.fontFamily = props.fontFamily;
+  if (props.fontSize && FONT_SIZE.test(props.fontSize)) {
+    const n = Number(props.fontSize);
+    if (n >= 6 && n <= 96) css.fontSize = `${n}pt`;
+  }
+  if (props.wrap === '1') css.whiteSpace = 'normal';
   return css;
 }
 


### PR DESCRIPTION
Rebuilds the spreadsheet chrome as a faithful Microsoft-365-Excel replica. Built in two waves of parallel agents (ribbon UI / chrome / props pipeline / E2E) against fixed interface contracts, then integrated.

## Excel window
- **Green title bar** (#107C41) with workbook icon + pad name; chrome (title bar, ribbon, formula bar, sheet tabs, status bar) is **pinned to the viewport — only the grid scrolls**, with always-sticky column letters and row numbers.
- **Classic full-height ribbon** with inline-SVG icons: green **File** tab (menu: Import/Export .xlsx), **Home** (Clipboard with big Paste + Cut/Copy, Font with family/size combos + B/I/U/borders/colors, Alignment + Wrap text, Number, Cells insert/delete rows+cols, Editing with Σ AutoSum), **Data** (Get & Transform Import/Export, Sort A→Z / Z→A, filter), **View** (freeze panes).
- **Formula bar** with name box, ✕ Cancel / ✓ Enter buttons and italic fx.
- **Status bar**: Ready + live selection statistics (Average / Count / Sum — formula cells count with their computed value, like Excel).
- Grid: Excel-green selection, selected row/column header highlight, nowrap cells with focused-cell overflow like Excel, #d4d4d4 gridlines.

## Real features behind the chrome (no dead buttons)
- New validated style props through the whole pipeline (server allowlist in Op.Validate + client CSS mapping): **fontFamily** (6-font allowlist), **fontSize** (6–96pt), **wrap**.
- Ribbon Clipboard buttons reuse the existing TSV cut/copy/paste logic; Σ AutoSum starts `=SUM()` in the formula bar with the caret inside the parens.
- xlsx Import/Export and row/column insert/delete wire the existing server endpoints/ops.

## Tests
- Go + TS unit tests green (81 sheet tests, new prop-validation cases incl. injection defense).
- E2E: new `sheet_excel_chrome.spec.ts` (8 tests: title bar, font props, wrap, AutoSum flow, fx ✕/✓, status-bar stats, ribbon clipboard, header highlight) + updated ribbon/structural/formatting specs. **Full sheet suite live against a local build: 28/28 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
