### PR TITLE
fix(ci): ship the sheet bundle in built-assets and docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,11 +87,13 @@ jobs:
           mkdir -p built-assets/js/timeslider/assets
           mkdir -p built-assets/js/pad/assets
           mkdir -p built-assets/js/welcome/assets
+          mkdir -p built-assets/js/sheet/assets
           mkdir -p built-assets/css/build
           cp -r assets/js/admin/* built-assets/js/admin/
           cp assets/js/timeslider/assets/timeslider.js built-assets/js/timeslider/assets/
           cp assets/js/pad/assets/pad.js built-assets/js/pad/assets/
           cp assets/js/welcome/assets/welcome.js built-assets/js/welcome/assets/
+          cp assets/js/sheet/assets/sheet.js built-assets/js/sheet/assets/
           cp -r assets/css/build/* built-assets/css/build/
       - name: Upload assets
         if: matrix.arch == 'amd64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY ./assets/js/admin ./assets/js/admin
 COPY ./assets/js/timeslider/assets/timeslider.js ./assets/js/timeslider/assets/timeslider.js
 COPY ./assets/js/pad/assets/pad.js ./assets/js/pad/assets/pad.js
 COPY ./assets/js/welcome/assets/welcome.js ./assets/js/welcome/assets/welcome.js
+COPY ./assets/js/sheet/assets/sheet.js ./assets/js/sheet/assets/sheet.js
 COPY ./assets/css/build ./assets/css/build
 
 RUN templ generate


### PR DESCRIPTION
Deployed instances (e.g. etherpad-go-dev.samtv.fyi) 404 on /js/sheet/assets/sheet.js: the CI "Prepare built assets" step predates the spreadsheet and never copies sheet.js into the built-assets artifact. The docker job builds from a fresh checkout (built assets are gitignored) + that artifact, so the go:embed binary ships without the sheet bundle — the sheet page loads but its script does not exist.

Fix: copy assets/js/sheet/assets/sheet.js into the artifact (build.yml) and into the local Dockerfile asset COPY list. After merging, the next image build serves the sheet again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)