### PR TITLE
fix(settings): type the SSO admin client in the template

### DIFF
--- a/settings.template.json
+++ b/settings.template.json
@@ -146,6 +146,7 @@
     "issuer": "http://localhost:9001",
     "clients": [
       {
+        "type": "admin",
         "client_id": "admin_client",
         "client_secret": "admin",
         "grant_types": ["authorization_code"],
@@ -153,6 +154,7 @@
         "redirect_uris": ["http://localhost:9001/admin/"]
       },
       {
+        "type": "user",
         "client_id": "user_client",
         "client_secret": "user",
         "grant_types": ["authorization_code"],


### PR DESCRIPTION
## What

Add the missing `"type"` field to the example SSO clients in `settings.template.json` (`"admin"` and `"user"`).

## Why

`SSO.GetAdminClient()` (`lib/settings/Settings.go:162`) only returns a client whose `Type == "admin"`. The shipped template's example admin client had no `type` field, so copying the template verbatim still left the admin API disabled:

```
WARN  api/init.go:25  SSO admin client is not configured, cannot start admin API
```

With the admin API never registered, the admin panel's `/admin/ws` WebSocket route doesn't exist and the browser handshake fails.

Fixes #336.