### PR TITLE
feat(ci): generate release notes with git-cliff on tag release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,7 +469,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate release notes
-        id: git-cliff
+        id: git_cliff
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
@@ -494,7 +494,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: binaries/*
-          body: ${{ steps.git-cliff.outputs.content }}
+          body: ${{ steps.git_cliff.outputs.content }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -465,6 +465,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all binaries
         uses: actions/download-artifact@v8
@@ -483,7 +494,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: binaries/*
-          generate_release_notes: true
+          body: ${{ steps.git-cliff.outputs.content }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,75 @@
+# git-cliff configuration — https://git-cliff.org/docs/configuration
+# Generates release notes from Conventional Commits + semver (v*) tags.
+# Used by the `create-release` job in .github/workflows/build.yml.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented here.\n
+"""
+# Release-notes body for a single version. GitHub links are hard-coded to the
+# repo so the template works whether or not remote enrichment is active.
+body = """
+{% if version %}\
+    {% if previous.version %}\
+        ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/ether/etherpad-go/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+    {% else %}\
+        ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/ether/etherpad-go/tree/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+    {% endif %}\
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+            {% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}\
+            {% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](https://github.com/ether/etherpad-go/pull/{{ commit.remote.pr_number }}){% endif %}\
+    {% endfor %}
+{% endfor %}
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+    ### New Contributors ❤️
+    {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+        - @{{ contributor.username }} made their first contribution\
+            {% if contributor.pr_number %} in [#{{ contributor.pr_number }}](https://github.com/ether/etherpad-go/pull/{{ contributor.pr_number }}){% endif %}
+    {% endfor %}
+{% endif %}\n
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9]*"
+topo_order = false
+sort_commits = "oldest"
+
+# Strip the trailing " (#123)" squash-merge suffix so the PR link isn't duplicated.
+commit_preprocessors = [
+  { pattern = ' *\(#[0-9]+\)', replace = "" },
+]
+
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^perf", group = "<!-- 2 -->⚡ Performance" },
+  { message = "^refactor", group = "<!-- 3 -->🚜 Refactor" },
+  { message = "^docs", group = "<!-- 4 -->📚 Documentation" },
+  { message = "^test", group = "<!-- 5 -->🧪 Testing" },
+  { message = "^(ci|build)", group = "<!-- 6 -->⚙️ CI & Build" },
+  { message = "^chore\\(deps.*\\)", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^(chore|style)", group = "<!-- 7 -->🧹 Miscellaneous" },
+  { message = "^revert", group = "<!-- 8 -->◀️ Revert" },
+]
+
+[remote.github]
+owner = "ether"
+repo = "etherpad-go"

--- a/cliff.toml
+++ b/cliff.toml
@@ -47,7 +47,7 @@ filter_unconventional = true
 split_commits = false
 protect_breaking_commits = false
 filter_commits = false
-tag_pattern = "v[0-9]*"
+tag_pattern = '^v[0-9]+\.[0-9]+\.[0-9]+'
 topo_order = false
 sort_commits = "oldest"
 


### PR DESCRIPTION
Add a cliff.toml (Conventional Commits + semver v* tags) and swap the create-release job's generic generate_release_notes for git-cliff output: grouped, scoped, PR-linked notes with a compare link and first-time contributors. Checkout now fetches full history so git-cliff can walk tags.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
