### PR TITLE
feat(sheet): merged cells

### DIFF
--- a/lib/sheet/apply.go
+++ b/lib/sheet/apply.go
@@ -97,6 +97,24 @@ func (w *Workbook) Apply(op Op) error {
 	case OpSetFreeze:
 		s.FrozenRows = op.FrozenRows
 		s.FrozenCols = op.FrozenCols
+	case OpMergeCells:
+		if op.EndRow == op.Row && op.EndCol == op.Col {
+			return nil // degenerate 1x1 (e.g. collapsed by a rebase): no-op
+		}
+		// Excel semantics: merging over existing merges absorbs them. Cell
+		// content is kept (the view hides non-anchor cells; unmerge reveals it).
+		for a, sp := range s.Merges {
+			if intersects(a, sp, op.Row, op.Col, op.EndRow, op.EndCol) {
+				delete(s.Merges, a)
+			}
+		}
+		s.Merges[CellRef{op.Row, op.Col}] = Span{Rows: op.EndRow - op.Row + 1, Cols: op.EndCol - op.Col + 1}
+	case OpUnmergeCells:
+		for a, sp := range s.Merges {
+			if intersects(a, sp, op.Row, op.Col, op.EndRow, op.EndCol) {
+				delete(s.Merges, a)
+			}
+		}
 	case OpInsertRows:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Row >= op.Index {
@@ -105,6 +123,7 @@ func (w *Workbook) Apply(op Op) error {
 			return r, true
 		})
 		s.RowHeights = shiftDims(s.RowHeights, op.Index, op.Count)
+		s.Merges = shiftMerges(s.Merges, "row", op.Index, op.Count)
 	case OpDeleteRows:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Row >= op.Index && r.Row < op.Index+op.Count {
@@ -116,6 +135,7 @@ func (w *Workbook) Apply(op Op) error {
 			return r, true
 		})
 		s.RowHeights = shiftDims(s.RowHeights, op.Index, -op.Count)
+		s.Merges = shiftMerges(s.Merges, "row", op.Index, -op.Count)
 	case OpInsertCols:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Col >= op.Index {
@@ -124,6 +144,7 @@ func (w *Workbook) Apply(op Op) error {
 			return r, true
 		})
 		s.ColWidths = shiftDims(s.ColWidths, op.Index, op.Count)
+		s.Merges = shiftMerges(s.Merges, "col", op.Index, op.Count)
 	case OpDeleteCols:
 		s.remap(func(r CellRef) (CellRef, bool) {
 			if r.Col >= op.Index && r.Col < op.Index+op.Count {
@@ -135,6 +156,7 @@ func (w *Workbook) Apply(op Op) error {
 			return r, true
 		})
 		s.ColWidths = shiftDims(s.ColWidths, op.Index, -op.Count)
+		s.Merges = shiftMerges(s.Merges, "col", op.Index, -op.Count)
 	default:
 		return fmt.Errorf("apply: unhandled op type %q", op.Type)
 	}

--- a/lib/sheet/merge_test.go
+++ b/lib/sheet/merge_test.go
@@ -1,0 +1,133 @@
+package sheet
+
+import "testing"
+
+func mergeOp(sheet string, r0, c0, r1, c1 int) Op {
+	return Op{Type: OpMergeCells, Sheet: sheet, Row: r0, Col: c0, EndRow: r1, EndCol: c1}
+}
+
+func TestMergeUnmergeApply(t *testing.T) {
+	wb := NewWorkbook()
+	wb.AddSheet("s1", "Sheet1")
+
+	if err := wb.Apply(mergeOp("s1", 1, 1, 3, 2)); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	s := wb.SheetByID("s1")
+	if sp := s.Merges[CellRef{1, 1}]; sp != (Span{Rows: 3, Cols: 2}) {
+		t.Fatalf("merge span = %+v", sp)
+	}
+
+	// Overlapping merge absorbs the existing one (Excel semantics).
+	if err := wb.Apply(mergeOp("s1", 2, 2, 5, 5)); err != nil {
+		t.Fatalf("merge 2: %v", err)
+	}
+	if len(s.Merges) != 1 {
+		t.Fatalf("expected absorb, merges = %v", s.Merges)
+	}
+	if sp := s.Merges[CellRef{2, 2}]; sp != (Span{Rows: 4, Cols: 4}) {
+		t.Fatalf("absorbed span = %+v", sp)
+	}
+
+	// Unmerge by any intersecting rectangle.
+	if err := wb.Apply(Op{Type: OpUnmergeCells, Sheet: "s1", Row: 3, Col: 3, EndRow: 3, EndCol: 3}); err != nil {
+		t.Fatalf("unmerge: %v", err)
+	}
+	if len(s.Merges) != 0 {
+		t.Fatalf("merges left after unmerge: %v", s.Merges)
+	}
+
+	// Degenerate 1x1 merge (possible after rebase) is a no-op, not an error.
+	if err := wb.Apply(mergeOp("s1", 0, 0, 0, 0)); err != nil {
+		t.Fatalf("1x1 merge: %v", err)
+	}
+	if len(s.Merges) != 0 {
+		t.Fatalf("1x1 merge stored: %v", s.Merges)
+	}
+}
+
+func TestMergeStructuralShifts(t *testing.T) {
+	newWb := func() *Workbook {
+		wb := NewWorkbook()
+		wb.AddSheet("s1", "Sheet1")
+		// rows 2-4, cols 1-2
+		if err := wb.Apply(mergeOp("s1", 2, 1, 4, 2)); err != nil {
+			t.Fatalf("seed merge: %v", err)
+		}
+		return wb
+	}
+
+	// Insert above: merge moves down.
+	wb := newWb()
+	_ = wb.Apply(Op{Type: OpInsertRows, Sheet: "s1", Index: 0, Count: 2})
+	if sp, ok := wb.SheetByID("s1").Merges[CellRef{4, 1}]; !ok || sp != (Span{3, 2}) {
+		t.Fatalf("insert above: %v", wb.SheetByID("s1").Merges)
+	}
+
+	// Insert inside: merge grows.
+	wb = newWb()
+	_ = wb.Apply(Op{Type: OpInsertRows, Sheet: "s1", Index: 3, Count: 1})
+	if sp, ok := wb.SheetByID("s1").Merges[CellRef{2, 1}]; !ok || sp != (Span{4, 2}) {
+		t.Fatalf("insert inside: %v", wb.SheetByID("s1").Merges)
+	}
+
+	// Delete a band overlapping the bottom: merge shrinks.
+	wb = newWb()
+	_ = wb.Apply(Op{Type: OpDeleteRows, Sheet: "s1", Index: 4, Count: 3})
+	if sp, ok := wb.SheetByID("s1").Merges[CellRef{2, 1}]; !ok || sp != (Span{2, 2}) {
+		t.Fatalf("delete bottom: %v", wb.SheetByID("s1").Merges)
+	}
+
+	// Delete the whole row range: merge is dropped.
+	wb = newWb()
+	_ = wb.Apply(Op{Type: OpDeleteRows, Sheet: "s1", Index: 2, Count: 3})
+	if len(wb.SheetByID("s1").Merges) != 0 {
+		t.Fatalf("delete all rows: %v", wb.SheetByID("s1").Merges)
+	}
+
+	// Delete cols so the merge collapses to a single column AND single... no:
+	// rows stay 3, cols 2->1: still a 3x1 merge (kept). Deleting both cols drops it.
+	wb = newWb()
+	_ = wb.Apply(Op{Type: OpDeleteCols, Sheet: "s1", Index: 1, Count: 1})
+	if sp, ok := wb.SheetByID("s1").Merges[CellRef{2, 1}]; !ok || sp != (Span{3, 1}) {
+		t.Fatalf("delete one col: %v", wb.SheetByID("s1").Merges)
+	}
+	_ = wb.Apply(Op{Type: OpDeleteCols, Sheet: "s1", Index: 1, Count: 1})
+	if len(wb.SheetByID("s1").Merges) != 0 {
+		t.Fatalf("delete both cols: %v", wb.SheetByID("s1").Merges)
+	}
+}
+
+func TestMergeTransform(t *testing.T) {
+	in := mergeOp("s1", 2, 1, 4, 2)
+	out := Transform(in, Op{Type: OpInsertRows, Sheet: "s1", Index: 3, Count: 2})
+	if out.Row != 2 || out.EndRow != 6 {
+		t.Fatalf("transform insert: %+v", out)
+	}
+	out = Transform(in, Op{Type: OpDeleteRows, Sheet: "s1", Index: 0, Count: 2})
+	if out.Row != 0 || out.EndRow != 2 {
+		t.Fatalf("transform delete: %+v", out)
+	}
+	// Concurrent delete of the entire range collapses the merge to 1x1 in one
+	// dimension; Submit must not error (Apply no-ops when fully degenerate).
+	out = Transform(in, Op{Type: OpDeleteRows, Sheet: "s1", Index: 2, Count: 3})
+	if out.Row != 2 || out.EndRow != 2 {
+		t.Fatalf("transform collapse: %+v", out)
+	}
+	if err := out.Validate(); err != nil {
+		t.Fatalf("collapsed merge must stay valid: %v", err)
+	}
+}
+
+func TestMergeSnapshotRoundTrip(t *testing.T) {
+	wb := NewWorkbook()
+	wb.AddSheet("s1", "Sheet1")
+	_ = wb.Apply(mergeOp("s1", 0, 0, 1, 1))
+	_ = wb.Apply(mergeOp("s1", 5, 5, 5, 7))
+
+	got := WorkbookFromSnapshot(wb.Snapshot())
+	s := got.SheetByID("s1")
+	if len(s.Merges) != 2 || s.Merges[CellRef{0, 0}] != (Span{2, 2}) || s.Merges[CellRef{5, 5}] != (Span{1, 3}) {
+		t.Fatalf("snapshot roundtrip merges = %v", s.Merges)
+	}
+}

--- a/lib/sheet/merge_test.go
+++ b/lib/sheet/merge_test.go
@@ -64,6 +64,14 @@ func TestMergeStructuralShifts(t *testing.T) {
 		t.Fatalf("insert above: %v", wb.SheetByID("s1").Merges)
 	}
 
+	// Insert exactly at the trailing edge (row 5, right after rows 2-4):
+	// the merge must NOT grow (qodo finding on the exclusive-end shift).
+	wb = newWb()
+	_ = wb.Apply(Op{Type: OpInsertRows, Sheet: "s1", Index: 5, Count: 2})
+	if sp, ok := wb.SheetByID("s1").Merges[CellRef{2, 1}]; !ok || sp != (Span{3, 2}) {
+		t.Fatalf("insert at trailing edge: %v", wb.SheetByID("s1").Merges)
+	}
+
 	// Insert inside: merge grows.
 	wb = newWb()
 	_ = wb.Apply(Op{Type: OpInsertRows, Sheet: "s1", Index: 3, Count: 1})

--- a/lib/sheet/op.go
+++ b/lib/sheet/op.go
@@ -24,6 +24,9 @@ const (
 	// Grid metadata ops.
 	OpSetDimension OpType = "setDimension"
 	OpSetFreeze    OpType = "setFreeze"
+	// Merged cells: both carry the Row/Col..EndRow/EndCol rectangle.
+	OpMergeCells   OpType = "mergeCells"
+	OpUnmergeCells OpType = "unmergeCells"
 )
 
 // Op is one cell-based operation. BaseRev is the workbook revision the client
@@ -103,9 +106,11 @@ func (o Op) Validate() error {
 		if err := ValidateProps(o.Props); err != nil {
 			return err
 		}
-	case OpClearRange:
+	// mergeCells allows a degenerate 1x1 rectangle (Apply no-ops it): rebasing
+	// past a concurrent row/col delete can collapse a valid merge to one cell.
+	case OpClearRange, OpMergeCells, OpUnmergeCells:
 		if o.Row < 0 || o.Col < 0 || o.EndRow < o.Row || o.EndCol < o.Col {
-			return fmt.Errorf("clearRange invalid bounds")
+			return fmt.Errorf("%s invalid bounds", o.Type)
 		}
 	case OpInsertRows, OpDeleteRows, OpInsertCols, OpDeleteCols:
 		if o.Index < 0 {

--- a/lib/sheet/sheet.go
+++ b/lib/sheet/sheet.go
@@ -2,6 +2,13 @@ package sheet
 
 import "maps"
 
+// Span is the extent of a merged-cell range, keyed by its top-left anchor.
+// Rows/Cols >= 1; a 1x1 span is never stored.
+type Span struct {
+	Rows int `json:"rows"`
+	Cols int `json:"cols"`
+}
+
 // Sheet is a single tab: sparse cells plus structural metadata.
 type Sheet struct {
 	Id    string           `json:"id"`
@@ -13,10 +20,13 @@ type Sheet struct {
 	// 0 or 1 each: freeze the first row / first col (position: sticky in the view).
 	FrozenRows int `json:"-"`
 	FrozenCols int `json:"-"`
+	// Merged-cell ranges keyed by top-left anchor. Non-anchor cells keep their
+	// content (hidden by the view); unmerge reveals it again.
+	Merges map[CellRef]Span `json:"-"`
 }
 
 func NewSheet(id, name string) *Sheet {
-	return &Sheet{Id: id, Name: name, Cells: map[CellRef]Cell{}, ColWidths: map[int]int{}, RowHeights: map[int]int{}}
+	return &Sheet{Id: id, Name: name, Cells: map[CellRef]Cell{}, ColWidths: map[int]int{}, RowHeights: map[int]int{}, Merges: map[CellRef]Span{}}
 }
 
 // SetCell stores a cell, dropping it from storage if empty (keeps it sparse).
@@ -38,6 +48,7 @@ func (s *Sheet) clone() *Sheet {
 		Id: s.Id, Name: s.Name, Cells: make(map[CellRef]Cell, len(s.Cells)),
 		ColWidths: maps.Clone(s.ColWidths), RowHeights: maps.Clone(s.RowHeights),
 		FrozenRows: s.FrozenRows, FrozenCols: s.FrozenCols,
+		Merges: maps.Clone(s.Merges),
 	}
 	maps.Copy(cp.Cells, s.Cells)
 	return cp
@@ -56,6 +67,48 @@ func shiftDims(m map[int]int, index, delta int) map[int]int {
 			continue // deleted band
 		}
 		next[shiftCoord(i, index, delta)] = v
+	}
+	return next
+}
+
+// intersects reports whether the merge at anchor overlaps the inclusive
+// rectangle [r0..r1] x [c0..c1].
+func intersects(anchor CellRef, sp Span, r0, c0, r1, c1 int) bool {
+	return anchor.Row <= r1 && anchor.Row+sp.Rows-1 >= r0 &&
+		anchor.Col <= c1 && anchor.Col+sp.Cols-1 >= c0
+}
+
+// shiftMerges rebuilds the merge map after a row (axis "row") or col insert
+// (delta > 0) / delete of -delta indices at index. Endpoints shift like cell
+// coordinates (an insert inside a merge grows it, a delete shrinks it);
+// merges that collapse to a single cell are dropped.
+func shiftMerges(m map[CellRef]Span, axis string, index, delta int) map[CellRef]Span {
+	if len(m) == 0 {
+		return m
+	}
+	next := make(map[CellRef]Span, len(m))
+	for a, sp := range m {
+		lo, span := a.Row, sp.Rows
+		if axis == "col" {
+			lo, span = a.Col, sp.Cols
+		}
+		// Shift the anchor and the EXCLUSIVE end: shiftCoord clamps in-band
+		// coords to index, which is exactly right for an exclusive bound.
+		nlo := shiftCoord(lo, index, delta)
+		nspan := shiftCoord(lo+span, index, delta) - nlo
+		if nspan <= 0 {
+			continue // merge entirely inside a deleted band
+		}
+		na, nsp := a, sp
+		if axis == "col" {
+			na.Col, nsp.Cols = nlo, nspan
+		} else {
+			na.Row, nsp.Rows = nlo, nspan
+		}
+		if nsp.Rows <= 1 && nsp.Cols <= 1 {
+			continue // collapsed to a single cell
+		}
+		next[na] = nsp
 	}
 	return next
 }

--- a/lib/sheet/sheet.go
+++ b/lib/sheet/sheet.go
@@ -92,10 +92,12 @@ func shiftMerges(m map[CellRef]Span, axis string, index, delta int) map[CellRef]
 		if axis == "col" {
 			lo, span = a.Col, sp.Cols
 		}
-		// Shift the anchor and the EXCLUSIVE end: shiftCoord clamps in-band
-		// coords to index, which is exactly right for an exclusive bound.
+		// Shift the anchor and the EXCLUSIVE end. The end needs shiftEnd: on
+		// insert an exclusive bound only moves for index STRICTLY inside
+		// (coord > index), or an insert at the merge's trailing edge would
+		// grow it; on delete shiftCoord's in-band clamp is exactly right.
 		nlo := shiftCoord(lo, index, delta)
-		nspan := shiftCoord(lo+span, index, delta) - nlo
+		nspan := shiftEnd(lo+span, index, delta) - nlo
 		if nspan <= 0 {
 			continue // merge entirely inside a deleted band
 		}
@@ -111,6 +113,15 @@ func shiftMerges(m map[CellRef]Span, axis string, index, delta int) map[CellRef]
 		next[na] = nsp
 	}
 	return next
+}
+
+// shiftEnd shifts an EXCLUSIVE upper bound: like shiftCoord, except an insert
+// exactly at the bound (coord == index) does not move it.
+func shiftEnd(coord, index, delta int) int {
+	if delta >= 0 && coord == index {
+		return coord
+	}
+	return shiftCoord(coord, index, delta)
 }
 
 // remap rebuilds the sparse cell map by transforming each ref. The fn returns

--- a/lib/sheet/snapshot.go
+++ b/lib/sheet/snapshot.go
@@ -16,15 +16,24 @@ type CellSnapshot struct {
 	StyleId   int    `json:"styleId,omitempty"`
 }
 
+// MergeSnapshot is one merged range: top-left anchor plus its span.
+type MergeSnapshot struct {
+	Row  int `json:"row"`
+	Col  int `json:"col"`
+	Rows int `json:"rows"`
+	Cols int `json:"cols"`
+}
+
 type SheetSnapshot struct {
 	Id    string         `json:"id"`
 	Name  string         `json:"name"`
 	Cells []CellSnapshot `json:"cells"`
 	// Sparse dimension overrides; JSON object keys are stringified indices.
-	ColWidths  map[int]int `json:"colWidths,omitempty"`
-	RowHeights map[int]int `json:"rowHeights,omitempty"`
-	FrozenRows int         `json:"frozenRows,omitempty"`
-	FrozenCols int         `json:"frozenCols,omitempty"`
+	ColWidths  map[int]int     `json:"colWidths,omitempty"`
+	RowHeights map[int]int     `json:"rowHeights,omitempty"`
+	FrozenRows int             `json:"frozenRows,omitempty"`
+	FrozenCols int             `json:"frozenCols,omitempty"`
+	Merges     []MergeSnapshot `json:"merges,omitempty"`
 }
 
 // WorkbookSnapshot is the JSON-serializable form of a Workbook for persistence.
@@ -57,6 +66,15 @@ func (w *Workbook) Snapshot() WorkbookSnapshot {
 		if len(s.RowHeights) > 0 {
 			ss.RowHeights = maps.Clone(s.RowHeights)
 		}
+		for a, sp := range s.Merges {
+			ss.Merges = append(ss.Merges, MergeSnapshot{a.Row, a.Col, sp.Rows, sp.Cols})
+		}
+		sort.Slice(ss.Merges, func(a, b int) bool {
+			if ss.Merges[a].Row != ss.Merges[b].Row {
+				return ss.Merges[a].Row < ss.Merges[b].Row
+			}
+			return ss.Merges[a].Col < ss.Merges[b].Col
+		})
 		out.Sheets[i] = ss
 	}
 	return out
@@ -86,6 +104,9 @@ func WorkbookFromSnapshot(snap WorkbookSnapshot) *Workbook {
 		maps.Copy(sh.ColWidths, ss.ColWidths)
 		maps.Copy(sh.RowHeights, ss.RowHeights)
 		sh.FrozenRows, sh.FrozenCols = ss.FrozenRows, ss.FrozenCols
+		for _, m := range ss.Merges {
+			sh.Merges[CellRef{m.Row, m.Col}] = Span{Rows: m.Rows, Cols: m.Cols}
+		}
 		w.Sheets[i] = sh
 	}
 	return w

--- a/lib/sheet/transform.go
+++ b/lib/sheet/transform.go
@@ -23,9 +23,14 @@ func Transform(in, applied Op) Op {
 
 // shiftRows moves row coordinates of `in` by delta for rows at/after index.
 // delta > 0 is an insert; delta < 0 is a delete (band [index, index-delta)).
+// hasRange reports whether the op carries an EndRow/EndCol rectangle.
+func hasRange(t OpType) bool {
+	return t == OpClearRange || t == OpMergeCells || t == OpUnmergeCells
+}
+
 func shiftRows(in Op, index, delta int) Op {
 	in.Row = shiftCoord(in.Row, index, delta)
-	if in.Type == OpClearRange {
+	if hasRange(in.Type) {
 		in.EndRow = shiftCoord(in.EndRow, index, delta)
 	}
 	if in.Type == OpInsertRows || in.Type == OpDeleteRows {
@@ -39,7 +44,7 @@ func shiftRows(in Op, index, delta int) Op {
 
 func shiftCols(in Op, index, delta int) Op {
 	in.Col = shiftCoord(in.Col, index, delta)
-	if in.Type == OpClearRange {
+	if hasRange(in.Type) {
 		in.EndCol = shiftCoord(in.EndCol, index, delta)
 	}
 	if in.Type == OpInsertCols || in.Type == OpDeleteCols {

--- a/lib/xlsx/export.go
+++ b/lib/xlsx/export.go
@@ -10,8 +10,8 @@ import (
 
 // Export renders a workbook to .xlsx bytes. Cells whose raw starts with '='
 // become formulas; numeric-looking raw is written as a number, the rest as a
-// string. Cell styles, column widths / row heights and freeze panes are
-// carried over; merges are not (the sheet model does not store them).
+// string. Cell styles, column widths / row heights, merged ranges and freeze
+// panes are carried over.
 func Export(wb *sheet.Workbook) ([]byte, error) {
 	f := excelize.NewFile()
 	defer f.Close()

--- a/lib/xlsx/export.go
+++ b/lib/xlsx/export.go
@@ -100,6 +100,20 @@ func Export(wb *sheet.Workbook) ([]byte, error) {
 			}
 		}
 
+		for a, sp := range s.Merges {
+			start, err := excelize.CoordinatesToCellName(a.Col+1, a.Row+1)
+			if err != nil {
+				return nil, err
+			}
+			end, err := excelize.CoordinatesToCellName(a.Col+sp.Cols, a.Row+sp.Rows)
+			if err != nil {
+				return nil, err
+			}
+			if err := f.MergeCell(name, start, end); err != nil {
+				return nil, err
+			}
+		}
+
 		if s.FrozenRows > 0 || s.FrozenCols > 0 {
 			topLeft, err := excelize.CoordinatesToCellName(s.FrozenCols+1, s.FrozenRows+1)
 			if err != nil {

--- a/lib/xlsx/import.go
+++ b/lib/xlsx/import.go
@@ -106,6 +106,17 @@ func Import(r io.Reader) (sheet.WorkbookSnapshot, error) {
 			}
 		}
 
+		if mcs, merr := f.GetMergeCells(name); merr == nil {
+			for _, mc := range mcs {
+				c0, r0, e0 := excelize.CellNameToCoordinates(mc.GetStartAxis())
+				c1, r1, e1 := excelize.CellNameToCoordinates(mc.GetEndAxis())
+				if e0 != nil || e1 != nil || (r1 == r0 && c1 == c0) {
+					continue
+				}
+				sh.Merges[sheet.CellRef{Row: r0 - 1, Col: c0 - 1}] = sheet.Span{Rows: r1 - r0 + 1, Cols: c1 - c0 + 1}
+			}
+		}
+
 		// Freeze panes: the model only supports freezing the first row/col.
 		if panes, err := f.GetPanes(name); err == nil && panes.Freeze {
 			if panes.YSplit > 0 {

--- a/lib/xlsx/import.go
+++ b/lib/xlsx/import.go
@@ -16,8 +16,8 @@ const (
 
 // Import parses an .xlsx into a WorkbookSnapshot. Sheet id == sheet name. Cells
 // carry their raw value, or "=<formula>" when a formula is present. Cell styles
-// (allowlisted props only), column widths / row heights and freeze panes are
-// imported; merges are skipped (the sheet model does not store them).
+// (allowlisted props only), column widths / row heights, merged ranges and
+// freeze panes are imported.
 func Import(r io.Reader) (sheet.WorkbookSnapshot, error) {
 	f, err := excelize.OpenReader(r)
 	if err != nil {

--- a/lib/xlsx/import_test.go
+++ b/lib/xlsx/import_test.go
@@ -57,6 +57,7 @@ func TestRoundTripStylesDimsAndFreeze(t *testing.T) {
 	s.ColWidths[2] = 150
 	s.RowHeights[3] = 40
 	s.FrozenRows, s.FrozenCols = 1, 1
+	s.Merges[sheet.CellRef{Row: 4, Col: 0}] = sheet.Span{Rows: 2, Cols: 3}
 
 	data, err := Export(wb)
 	if err != nil {
@@ -95,6 +96,9 @@ func TestRoundTripStylesDimsAndFreeze(t *testing.T) {
 	}
 	if len(sh.ColWidths) != 1 || len(sh.RowHeights) != 1 {
 		t.Errorf("dims not sparse: cols=%v rows=%v", sh.ColWidths, sh.RowHeights)
+	}
+	if len(sh.Merges) != 1 || sh.Merges[sheet.CellRef{Row: 4, Col: 0}] != (sheet.Span{Rows: 2, Cols: 3}) {
+		t.Errorf("merges = %v", sh.Merges)
 	}
 }
 

--- a/playwright/specs/sheet_merge.spec.ts
+++ b/playwright/specs/sheet_merge.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const cell = (page: Page, r: number, c: number) =>
+  page.locator(`.sheet-grid tbody tr:nth-child(${r + 1}) td:nth-child(${c + 2})`);
+
+async function openSheet(page: Page, padId: string): Promise<void> {
+  await page.goto(`/s/${padId}`);
+  await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+}
+
+async function typeInto(page: Page, r: number, c: number, text: string): Promise<void> {
+  await cell(page, r, c).click();
+  await page.keyboard.type(text);
+  await page.keyboard.press('Enter');
+}
+
+async function selectRange(page: Page, r0: number, c0: number, r1: number, c1: number): Promise<void> {
+  await cell(page, r0, c0).hover();
+  await page.mouse.down();
+  await cell(page, r1, c1).hover();
+  await page.mouse.up();
+}
+
+const mergeBtn = (page: Page) => page.locator('.sheet-toolbar button[title="Merge / unmerge cells"]');
+
+test.describe('Sheet merged cells', () => {
+  test('merge spans the anchor, hides covered cells, unmerge restores', async ({ page }) => {
+    await openSheet(page, `merge-basic-${Date.now()}`);
+    await typeInto(page, 0, 0, 'kopf');
+    await typeInto(page, 1, 1, 'versteckt');
+
+    await selectRange(page, 0, 0, 1, 1);
+    await mergeBtn(page).click();
+    await page.waitForTimeout(400);
+
+    await expect(cell(page, 0, 0)).toHaveAttribute('colspan', '2');
+    await expect(cell(page, 0, 0)).toHaveAttribute('rowspan', '2');
+    await expect(cell(page, 1, 1)).toBeHidden();
+    await expect(cell(page, 0, 0)).toHaveText('kopf');
+
+    // unmerge: content of covered cells was kept, not deleted
+    await cell(page, 0, 0).click();
+    await mergeBtn(page).click();
+    await page.waitForTimeout(400);
+    await expect(cell(page, 1, 1)).toBeVisible();
+    await expect(cell(page, 1, 1)).toHaveText('versteckt');
+  });
+
+  test('merge persists across reload and reaches a second client', async ({ page, browser }) => {
+    const pad = `merge-collab-${Date.now()}`;
+    await openSheet(page, pad);
+    await selectRange(page, 2, 0, 2, 2);
+    await mergeBtn(page).click();
+    await page.waitForTimeout(400);
+
+    // second client sees the merge live
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await openSheet(page2, pad);
+    await expect(cell(page2, 2, 0)).toHaveAttribute('colspan', '3');
+    await ctx2.close();
+
+    // and it survives a reload (snapshot round-trip)
+    await page.reload();
+    await page.locator('.sheet-grid').waitFor({ state: 'visible', timeout: 20000 });
+    await expect(cell(page, 2, 0)).toHaveAttribute('colspan', '3');
+  });
+
+  test('inserting a row above shifts the merge down', async ({ page }) => {
+    await openSheet(page, `merge-shift-${Date.now()}`);
+    await selectRange(page, 3, 0, 4, 1);
+    await mergeBtn(page).click();
+    await page.waitForTimeout(400);
+    await expect(cell(page, 3, 0)).toHaveAttribute('rowspan', '2');
+
+    await cell(page, 0, 0).click();
+    await page.locator('.sheet-toolbar button[title="Insert row above"]').click();
+    await page.waitForTimeout(400);
+    await expect(cell(page, 4, 0)).toHaveAttribute('rowspan', '2');
+    await expect(cell(page, 3, 0)).not.toHaveAttribute('rowspan', '2');
+  });
+});

--- a/playwright/specs/sheet_merge.spec.ts
+++ b/playwright/specs/sheet_merge.spec.ts
@@ -79,4 +79,23 @@ test.describe('Sheet merged cells', () => {
     await expect(cell(page, 4, 0)).toHaveAttribute('rowspan', '2');
     await expect(cell(page, 3, 0)).not.toHaveAttribute('rowspan', '2');
   });
+
+  // Model semantics (absorb-on-overlap, insert-at-trailing-edge, delete-shrink)
+  // are covered by unit tests in workbookState.test.ts / merge_test.go and are
+  // not reachable through the toolbar toggle, so they stay out of the e2e layer.
+
+  test('arrow keys snap to the anchor and step past covered cells', async ({ page }) => {
+    await openSheet(page, `merge-nav-${Date.now()}`);
+    await selectRange(page, 1, 0, 2, 0); // merge A2:A3 (rows 1..2, col 0)
+    await mergeBtn(page).click();
+    await page.waitForTimeout(400);
+    await expect(cell(page, 1, 0)).toHaveAttribute('rowspan', '2');
+    await expect(cell(page, 2, 0)).toBeHidden();
+
+    await cell(page, 0, 0).click();
+    await page.keyboard.press('ArrowDown'); // into the merge → snaps to anchor
+    await expect(cell(page, 1, 0)).toHaveClass(/sheet-sel-focus/);
+    await page.keyboard.press('ArrowDown'); // leaving the merge → skips covered row
+    await expect(cell(page, 3, 0)).toHaveClass(/sheet-sel-focus/);
+  });
 });

--- a/ui/src/js/sheet/op.ts
+++ b/ui/src/js/sheet/op.ts
@@ -15,7 +15,9 @@ export type OpType =
   | 'deleteSheet'
   | 'moveSheet'
   | 'setDimension'
-  | 'setFreeze';
+  | 'setFreeze'
+  | 'mergeCells'
+  | 'unmergeCells';
 
 export interface Op {
   type: OpType;
@@ -24,7 +26,7 @@ export interface Op {
   // cell / range top-left
   row?: number;
   col?: number;
-  // range end (inclusive) for clearRange
+  // range end (inclusive) for clearRange / mergeCells / unmergeCells
   endRow?: number;
   endCol?: number;
   // setCell / setStyle payload

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -327,6 +327,28 @@ export function startSheetEditor(root: HTMLElement): void {
       autoSum: () => {
         if (!readOnly) formulaBar?.beginFormula('=SUM(');
       },
+      mergeToggle: () => {
+        if (readOnly || !collab) return;
+        blurActiveCell();
+        const { r0, c0, r1, c1 } = normalize(selection);
+        const s = collab.display.sheetById(activeSheetId);
+        // Any merge intersecting the selection → unmerge; otherwise merge.
+        let hit = false;
+        for (const [k, sp] of s?.merges ?? []) {
+          const i = k.indexOf(':');
+          const mr = Number(k.slice(0, i));
+          const mc = Number(k.slice(i + 1));
+          if (mr <= r1 && mr + sp.rows - 1 >= r0 && mc <= c1 && mc + sp.cols - 1 >= c0) {
+            hit = true;
+            break;
+          }
+        }
+        if (!hit && r0 === r1 && c0 === c1) return; // 1x1 merge is meaningless
+        collab.applyLocal({
+          type: hit ? 'unmergeCells' : 'mergeCells',
+          sheet: activeSheetId, baseRev: collab.rev, row: r0, col: c0, endRow: r1, endCol: c1,
+        });
+      },
     });
     formulaBar = createFormulaBar({
       readOnly: data.readonly,
@@ -404,6 +426,14 @@ export function startSheetEditor(root: HTMLElement): void {
         collab.applyLocal({ type: 'setDimension', sheet: activeSheetId, baseRev: collab.rev, axis, index, size });
       },
       rowHidden: (r) => hiddenRows.has(r),
+      merges: () => {
+        const s = collab?.display.sheetById(activeSheetId);
+        if (!s) return [];
+        return [...s.merges].map(([k, sp]) => {
+          const i = k.indexOf(':');
+          return { row: Number(k.slice(0, i)), col: Number(k.slice(i + 1)), rows: sp.rows, cols: sp.cols };
+        });
+      },
       // ponytail: second engine.getValue per formula cell per render (displayValue
       // already does one). Cheap: HyperFormula caches, and the raw.startsWith('=')
       // gate skips non-formula cells. Fold into displayValue if the grid grows.

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -22,6 +22,8 @@ export interface ToolbarCallbacks {
   // Ribbon: clipboard + quick aggregation (wired by the editor).
   clipboardAction?: (a: 'cut' | 'copy' | 'paste') => void;
   autoSum?: () => void;
+  // Merge/unmerge the current selection (the editor decides which).
+  mergeToggle?: () => void;
 }
 
 const CSS = `
@@ -72,6 +74,7 @@ const IC = {
   alignCenter: '<path d="M2.5 4h11M4.5 7h7M2.5 10h11M4.5 13h7"/>',
   alignRight: '<path d="M2.5 4h11M6.5 7h7M2.5 10h11M6.5 13h7"/>',
   wrap: '<path d="M2.5 4h11M2.5 8h8.5a2.5 2.5 0 0 1 0 5H8M2.5 12h3"/><path d="M9.5 11.5 8 13l1.5 1.5"/>',
+  merge: '<rect x="1.5" y="4.5" width="13" height="7"/><path d="M4.5 8h7M9.5 6 11.5 8 9.5 10M6.5 6 4.5 8l2 2"/>',
   insRowAbove: '<rect x="2.5" y="10.5" width="11" height="3"/><path d="M8 8.5V3M5.5 5.5 8 3l2.5 2.5"/>',
   insRowBelow: '<rect x="2.5" y="2.5" width="11" height="3"/><path d="M8 7.5V13M5.5 10.5 8 13l2.5-2.5"/>',
   insColLeft: '<rect x="10.5" y="2.5" width="3" height="11"/><path d="M8.5 8H3M5.5 5.5 3 8l2.5 2.5"/>',
@@ -281,6 +284,9 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
     btn(alignRow, { icon: alignIcons[a] }, `Align ${a}`, () => cb.applyToSelection({ align: a }));
   }
   toggleBtn(alignRow, { icon: IC.wrap }, 'Wrap text', 'wrap');
+  if (cb.mergeToggle) {
+    btn(alignRow, { icon: IC.merge }, 'Merge / unmerge cells', () => cb.mergeToggle?.());
+  }
 
   // --- Home: Number ---
   const numRow = group('Home', 'Number');

--- a/ui/src/js/sheet/sheetView.ts
+++ b/ui/src/js/sheet/sheetView.ts
@@ -39,6 +39,9 @@ export interface SheetViewOptions {
   onResize?: (axis: 'col' | 'row', index: number, sizePx: number) => void;
   // Client-local row filter: hidden rows collapse via display:none.
   rowHidden?: (row: number) => boolean;
+  // Merged ranges (top-left anchor + span). The anchor td gets rowSpan/colSpan,
+  // covered tds are display:none.
+  merges?: () => Array<{ row: number; col: number; rows: number; cols: number }>;
 }
 
 const STYLE_ID = 'sheet-grid-style';
@@ -94,6 +97,7 @@ export class DomSheetView {
   // corner. It lives OUTSIDE the contenteditable tds: a decoration inside an
   // editable cell races the caret and re-renders can delete typed text.
   private fillHandle: HTMLSpanElement;
+  private mergedTds = new Set<HTMLTableCellElement>();
   private table: HTMLTableElement;
   private thead: HTMLTableSectionElement;
   private colHeads: HTMLTableCellElement[] = [];
@@ -279,8 +283,23 @@ export class DomSheetView {
       const move = (dr: number, dc: number, extend: boolean) => {
         e.preventDefault();
         const f = this.selection.focus;
-        const nr = Math.min(this.opts.rows - 1, Math.max(0, f.row + dr));
-        const nc = Math.min(this.opts.cols - 1, Math.max(0, f.col + dc));
+        let nr = Math.min(this.opts.rows - 1, Math.max(0, f.row + dr));
+        let nc = Math.min(this.opts.cols - 1, Math.max(0, f.col + dc));
+        // Merged ranges: a covered (hidden) cell can't take focus — snap to
+        // the merge anchor, and step past the whole merge when leaving it.
+        const m = this.mergeAt(nr, nc);
+        if (m && !extend) {
+          if (m.row === f.row && m.col === f.col) {
+            // moving within our own merge: jump to the far side
+            nr = Math.min(this.opts.rows - 1, Math.max(0, dr > 0 ? m.row + m.rows : dr < 0 ? m.row - 1 : nr));
+            nc = Math.min(this.opts.cols - 1, Math.max(0, dc > 0 ? m.col + m.cols : dc < 0 ? m.col - 1 : nc));
+            const m2 = this.mergeAt(nr, nc);
+            if (m2) { nr = m2.row; nc = m2.col; }
+          } else {
+            nr = m.row;
+            nc = m.col;
+          }
+        }
         this.selection = extend
           ? { anchor: this.selection.anchor, focus: { row: nr, col: nc } }
           : selFromSingle(nr, nc);
@@ -350,6 +369,16 @@ export class DomSheetView {
     this.remoteSel = list;
   }
 
+  // mergeAt returns the merge covering (r, c), or null.
+  // ponytail: linear scan per lookup; merges per sheet are few. Index by cell
+  // key if sheets ever carry hundreds of merges.
+  private mergeAt(r: number, c: number): { row: number; col: number; rows: number; cols: number } | null {
+    for (const m of this.opts.merges?.() ?? []) {
+      if (r >= m.row && r < m.row + m.rows && c >= m.col && c < m.col + m.cols) return m;
+    }
+    return null;
+  }
+
   // render refreshes every non-editing cell to its display value, then paints
   // remote live-edit text and cursor/live-edit decorations.
   render(): void {
@@ -368,6 +397,31 @@ export class DomSheetView {
       this.applyDim('row', r, this.opts.rowHeight?.(r));
       this.rows[r].style.display = this.opts.rowHidden?.(r) ? 'none' : '';
     }
+    // Merged ranges: reset last render's spans, then apply the current set.
+    for (const td of this.mergedTds) {
+      td.rowSpan = 1;
+      td.colSpan = 1;
+      td.style.display = '';
+    }
+    this.mergedTds.clear();
+    for (const m of this.opts.merges?.() ?? []) {
+      const anchor = this.cells[m.row]?.[m.col];
+      if (!anchor) continue;
+      anchor.rowSpan = Math.min(m.rows, this.opts.rows - m.row);
+      anchor.colSpan = Math.min(m.cols, this.opts.cols - m.col);
+      this.mergedTds.add(anchor);
+      for (let r = m.row; r < Math.min(m.row + m.rows, this.opts.rows); r++) {
+        for (let c = m.col; c < Math.min(m.col + m.cols, this.opts.cols); c++) {
+          if (r === m.row && c === m.col) continue;
+          const td = this.cells[r]?.[c];
+          if (td) {
+            td.style.display = 'none';
+            this.mergedTds.add(td);
+          }
+        }
+      }
+    }
+
     const fz = this.opts.frozen?.() ?? { rows: 0, cols: 0 };
     this.table.classList.toggle('sheet-frozen-r', fz.rows > 0);
     this.table.classList.toggle('sheet-frozen-c', fz.cols > 0);

--- a/ui/src/js/sheet/transform.test.ts
+++ b/ui/src/js/sheet/transform.test.ts
@@ -34,4 +34,15 @@ describe('transform (port of Go Transform)', () => {
     const applied: Op = { type: 'insertCols', sheet: 's1', baseRev: 0, index: 1, count: 2 };
     expect(transform(setCell(0, 3), applied).col).toBe(5);
   });
+
+  it('mergeCells rectangle shifts like clearRange', () => {
+    const merge: Op = { type: 'mergeCells', sheet: 's1', baseRev: 0, row: 2, col: 1, endRow: 4, endCol: 2 };
+    const out = transform(merge, { type: 'insertRows', sheet: 's1', baseRev: 0, index: 3, count: 2 });
+    expect(out.row).toBe(2);
+    expect(out.endRow).toBe(6);
+    // delete of the whole range collapses to a degenerate rectangle (applyOp no-ops it)
+    const gone = transform(merge, { type: 'deleteRows', sheet: 's1', baseRev: 0, index: 2, count: 3 });
+    expect(gone.row).toBe(2);
+    expect(gone.endRow).toBe(2);
+  });
 });

--- a/ui/src/js/sheet/transform.ts
+++ b/ui/src/js/sheet/transform.ts
@@ -23,10 +23,14 @@ export function transform(inOp: Op, applied: Op): Op {
   }
 }
 
+// hasRange mirrors Go: ops that carry an endRow/endCol rectangle.
+const hasRange = (t: Op['type']): boolean =>
+  t === 'clearRange' || t === 'mergeCells' || t === 'unmergeCells';
+
 function shiftRows(inOp: Op, index: number, delta: number): Op {
   const out: Op = { ...inOp };
   out.row = shiftCoord(out.row ?? 0, index, delta);
-  if (out.type === 'clearRange') {
+  if (hasRange(out.type)) {
     out.endRow = shiftCoord(out.endRow ?? 0, index, delta);
   }
   if (out.type === 'insertRows' || out.type === 'deleteRows') {
@@ -41,7 +45,7 @@ function shiftRows(inOp: Op, index: number, delta: number): Op {
 function shiftCols(inOp: Op, index: number, delta: number): Op {
   const out: Op = { ...inOp };
   out.col = shiftCoord(out.col ?? 0, index, delta);
-  if (out.type === 'clearRange') {
+  if (hasRange(out.type)) {
     out.endCol = shiftCoord(out.endCol ?? 0, index, delta);
   }
   if (out.type === 'insertCols' || out.type === 'deleteCols') {

--- a/ui/src/js/sheet/workbookState.test.ts
+++ b/ui/src/js/sheet/workbookState.test.ts
@@ -57,6 +57,45 @@ describe('WorkbookState.applyOp (port of Go Apply)', () => {
   });
 });
 
+describe('WorkbookState merges (port of Go Apply)', () => {
+  it('mergeCells stores span; overlapping merge absorbs', () => {
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 1, col: 1, endRow: 3, endCol: 2 });
+    let s = wb.sheetById('s1')!;
+    expect(s.merges.get('1:1')).toEqual({ rows: 3, cols: 2 });
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 2, col: 2, endRow: 5, endCol: 5 });
+    s = wb.sheetById('s1')!;
+    expect(s.merges.size).toBe(1);
+    expect(s.merges.get('2:2')).toEqual({ rows: 4, cols: 4 });
+  });
+
+  it('unmergeCells drops intersecting merges; 1x1 merge is a no-op', () => {
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 1, col: 1, endRow: 3, endCol: 2 });
+    wb.applyOp({ type: 'unmergeCells', sheet: 's1', baseRev: 0, row: 2, col: 2, endRow: 2, endCol: 2 });
+    expect(wb.sheetById('s1')!.merges.size).toBe(0);
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 0, col: 0, endRow: 0, endCol: 0 });
+    expect(wb.sheetById('s1')!.merges.size).toBe(0);
+  });
+
+  it('structural ops shift, grow, shrink and drop merges', () => {
+    // rows 2-4, cols 1-2
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 2, col: 1, endRow: 4, endCol: 2 });
+    wb.applyOp({ type: 'insertRows', sheet: 's1', baseRev: 0, index: 3, count: 1 }); // inside: grows
+    expect(wb.sheetById('s1')!.merges.get('2:1')).toEqual({ rows: 4, cols: 2 });
+    wb.applyOp({ type: 'deleteRows', sheet: 's1', baseRev: 0, index: 0, count: 2 }); // above: moves up
+    expect(wb.sheetById('s1')!.merges.get('0:1')).toEqual({ rows: 4, cols: 2 });
+    wb.applyOp({ type: 'deleteCols', sheet: 's1', baseRev: 0, index: 1, count: 2 }); // all cols: dropped
+    expect(wb.sheetById('s1')!.merges.size).toBe(0);
+  });
+
+  it('loadSnapshot restores merges', () => {
+    const w2 = new WorkbookState();
+    w2.loadSnapshot({
+      sheets: [{ id: 's1', name: 'S', cells: [], merges: [{ row: 0, col: 0, rows: 2, cols: 3 }] }],
+    });
+    expect(w2.sheetById('s1')!.merges.get('0:0')).toEqual({ rows: 2, cols: 3 });
+  });
+});
+
 describe('WorkbookState style props', () => {
   it('setStyle op interns props and getStyleProps resolves them', () => {
     const wb = new WorkbookState();

--- a/ui/src/js/sheet/workbookState.test.ts
+++ b/ui/src/js/sheet/workbookState.test.ts
@@ -76,6 +76,13 @@ describe('WorkbookState merges (port of Go Apply)', () => {
     expect(wb.sheetById('s1')!.merges.size).toBe(0);
   });
 
+  it('insert at the trailing edge does not grow the merge', () => {
+    // rows 2-4: inserting at row 5 (right after) must leave the span at 3
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 2, col: 1, endRow: 4, endCol: 2 });
+    wb.applyOp({ type: 'insertRows', sheet: 's1', baseRev: 0, index: 5, count: 2 });
+    expect(wb.sheetById('s1')!.merges.get('2:1')).toEqual({ rows: 3, cols: 2 });
+  });
+
   it('structural ops shift, grow, shrink and drop merges', () => {
     // rows 2-4, cols 1-2
     wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 2, col: 1, endRow: 4, endCol: 2 });

--- a/ui/src/js/sheet/workbookState.ts
+++ b/ui/src/js/sheet/workbookState.ts
@@ -52,7 +52,7 @@ const shiftMerges = (m: Map<string, Span>, axis: 'row' | 'col', index: number, d
     const lo = axis === 'row' ? r : c;
     const span = axis === 'row' ? sp.rows : sp.cols;
     const nlo = shiftIdx2(lo, index, delta);
-    const nspan = shiftIdx2(lo + span, index, delta) - nlo;
+    const nspan = shiftEnd(lo + span, index, delta) - nlo;
     if (nspan <= 0) continue;
     const nr = axis === 'row' ? nlo : r;
     const nc = axis === 'col' ? nlo : c;
@@ -62,6 +62,11 @@ const shiftMerges = (m: Map<string, Span>, axis: 'row' | 'col', index: number, d
   }
   return next;
 };
+
+// shiftEnd mirrors Go shiftEnd: shifts an EXCLUSIVE upper bound — an insert
+// exactly at the bound (the merge's trailing edge) must not grow the merge.
+const shiftEnd = (coord: number, index: number, delta: number): number =>
+  delta >= 0 && coord === index ? coord : shiftIdx2(coord, index, delta);
 
 // shiftIdx2 mirrors Go shiftCoord (in-band coords clamp to index on delete);
 // shiftIdx above keeps dimension-map semantics (band entries dropped earlier).

--- a/ui/src/js/sheet/workbookState.ts
+++ b/ui/src/js/sheet/workbookState.ts
@@ -8,6 +8,11 @@ export interface Cell {
   styleId?: number;
 }
 
+export interface Span {
+  rows: number;
+  cols: number;
+}
+
 export interface SheetState {
   id: string;
   name: string;
@@ -16,6 +21,7 @@ export interface SheetState {
   rowHeights: Map<number, number>;
   frozenRows: number; // 0 or 1
   frozenCols: number;
+  merges: Map<string, Span>; // key "row:col" = top-left anchor
 }
 
 const key = (row: number, col: number): string => `${row}:${col}`;
@@ -29,7 +35,43 @@ const cellIsEmpty = (c: Cell): boolean =>
 
 const emptySheet = (id: string, name: string): SheetState => ({
   id, name, cells: new Map(), colWidths: new Map(), rowHeights: new Map(), frozenRows: 0, frozenCols: 0,
+  merges: new Map(),
 });
+
+// intersects mirrors Go: merge at (row,col) x span overlaps [r0..r1]x[c0..c1].
+const mergeIntersects = (row: number, col: number, sp: Span, r0: number, c0: number, r1: number, c1: number): boolean =>
+  row <= r1 && row + sp.rows - 1 >= r0 && col <= c1 && col + sp.cols - 1 >= c0;
+
+// shiftMerges mirrors Go shiftMerges: shift anchors and EXCLUSIVE ends like
+// cell coordinates; drop merges that collapse inside a deleted band or to 1x1.
+const shiftMerges = (m: Map<string, Span>, axis: 'row' | 'col', index: number, delta: number): Map<string, Span> => {
+  if (m.size === 0) return m;
+  const next = new Map<string, Span>();
+  for (const [k, sp] of m) {
+    const [r, c] = parseKey(k);
+    const lo = axis === 'row' ? r : c;
+    const span = axis === 'row' ? sp.rows : sp.cols;
+    const nlo = shiftIdx2(lo, index, delta);
+    const nspan = shiftIdx2(lo + span, index, delta) - nlo;
+    if (nspan <= 0) continue;
+    const nr = axis === 'row' ? nlo : r;
+    const nc = axis === 'col' ? nlo : c;
+    const nsp: Span = axis === 'row' ? { rows: nspan, cols: sp.cols } : { rows: sp.rows, cols: nspan };
+    if (nsp.rows <= 1 && nsp.cols <= 1) continue;
+    next.set(key(nr, nc), nsp);
+  }
+  return next;
+};
+
+// shiftIdx2 mirrors Go shiftCoord (in-band coords clamp to index on delete);
+// shiftIdx above keeps dimension-map semantics (band entries dropped earlier).
+const shiftIdx2 = (coord: number, index: number, delta: number): number => {
+  if (delta >= 0) return coord >= index ? coord + delta : coord;
+  const band = -delta;
+  if (coord < index) return coord;
+  if (coord < index + band) return index;
+  return coord - band;
+};
 
 // shiftDims mirrors Go shiftDims: rebuild a sparse dimension map after an
 // insert (delta>0) / delete of -delta indices at index (in-band entries drop).
@@ -57,6 +99,12 @@ export interface CellSnapshot {
   valueType?: string;
   styleId?: number;
 }
+export interface MergeSnapshot {
+  row: number;
+  col: number;
+  rows: number;
+  cols: number;
+}
 export interface SheetSnapshot {
   id: string;
   name: string;
@@ -65,6 +113,7 @@ export interface SheetSnapshot {
   rowHeights?: Record<string, number>;
   frozenRows?: number;
   frozenCols?: number;
+  merges?: MergeSnapshot[];
 }
 export interface WorkbookSnapshot {
   sheets: SheetSnapshot[];
@@ -97,6 +146,7 @@ export class WorkbookState {
       id: s.id, name: s.name, cells: new Map(s.cells),
       colWidths: new Map(s.colWidths), rowHeights: new Map(s.rowHeights),
       frozenRows: s.frozenRows, frozenCols: s.frozenCols,
+      merges: new Map(s.merges),
     }));
     cp.styles = this.styles; // shared pool: interning is monotonic + content-deduped
     return cp;
@@ -117,6 +167,7 @@ export class WorkbookState {
       for (const [i, v] of Object.entries(ss.rowHeights ?? {})) s.rowHeights.set(Number(i), v);
       s.frozenRows = ss.frozenRows ?? 0;
       s.frozenCols = ss.frozenCols ?? 0;
+      for (const m of ss.merges ?? []) s.merges.set(key(m.row, m.col), { rows: m.rows, cols: m.cols });
       return s;
     });
     this.styles.seed(snap.styles);
@@ -232,9 +283,31 @@ export class WorkbookState {
         sheet.frozenRows = op.frozenRows ?? 0;
         sheet.frozenCols = op.frozenCols ?? 0;
         break;
+      case 'mergeCells': {
+        const endRow = op.endRow ?? 0;
+        const endCol = op.endCol ?? 0;
+        if (endRow === row && endCol === col) break; // degenerate 1x1: no-op
+        // Excel semantics: merging over existing merges absorbs them.
+        for (const [k, sp] of [...sheet.merges]) {
+          const [r, c] = parseKey(k);
+          if (mergeIntersects(r, c, sp, row, col, endRow, endCol)) sheet.merges.delete(k);
+        }
+        sheet.merges.set(key(row, col), { rows: endRow - row + 1, cols: endCol - col + 1 });
+        break;
+      }
+      case 'unmergeCells': {
+        const endRow = op.endRow ?? 0;
+        const endCol = op.endCol ?? 0;
+        for (const [k, sp] of [...sheet.merges]) {
+          const [r, c] = parseKey(k);
+          if (mergeIntersects(r, c, sp, row, col, endRow, endCol)) sheet.merges.delete(k);
+        }
+        break;
+      }
       case 'insertRows':
         this.remap(sheet, (r, c) => (r >= index ? [r + count, c, true] : [r, c, true]));
         sheet.rowHeights = shiftDims(sheet.rowHeights, index, count);
+        sheet.merges = shiftMerges(sheet.merges, 'row', index, count);
         break;
       case 'deleteRows':
         this.remap(sheet, (r, c) => {
@@ -243,10 +316,12 @@ export class WorkbookState {
           return [r, c, true];
         });
         sheet.rowHeights = shiftDims(sheet.rowHeights, index, -count);
+        sheet.merges = shiftMerges(sheet.merges, 'row', index, -count);
         break;
       case 'insertCols':
         this.remap(sheet, (r, c) => (c >= index ? [r, c + count, true] : [r, c, true]));
         sheet.colWidths = shiftDims(sheet.colWidths, index, count);
+        sheet.merges = shiftMerges(sheet.merges, 'col', index, count);
         break;
       case 'deleteCols':
         this.remap(sheet, (r, c) => {
@@ -255,6 +330,7 @@ export class WorkbookState {
           return [r, c, true];
         });
         sheet.colWidths = shiftDims(sheet.colWidths, index, -count);
+        sheet.merges = shiftMerges(sheet.merges, 'col', index, -count);
         break;
       default:
         throw new Error(`applyOp: unhandled op type ${(op as Op).type}`);


### PR DESCRIPTION
## What

Merged cells for the collaborative spreadsheet, end to end:

**Model / ops (Go + TS mirror)** — `Sheet.Merges` (top-left anchor → span) plus two ops, `mergeCells` / `unmergeCells`, carrying the same rectangle as `clearRange`. Excel semantics: merging over existing merges absorbs them; unmerge drops every intersecting range. Non-anchor cell content is **kept** (hidden by the view), so unmerge restores it — no data loss.

**Structural interplay** — insert/delete rows/cols shift merges like cells: an insert inside a merge grows it, a delete shrinks it, merges fully inside a deleted band (or collapsed to 1x1) are dropped. `Transform` shifts the op rectangle like `clearRange`; a rebase past a concurrent delete can collapse a `mergeCells` op to 1x1, which `Apply` treats as a converging no-op instead of an error.

**View** — the anchor td gets `rowSpan`/`colSpan`, covered tds go `display:none`; arrow-key navigation snaps onto merge anchors and steps over the merged block. Ribbon Alignment group gains a merge/unmerge toggle (the editor picks the direction: any merge intersecting the selection → unmerge).

**xlsx** — merges round-trip through import/export via excelize `MergeCell`/`GetMergeCells`.

## Tests

- Go: apply (absorb/unmerge/1x1 no-op), structural shifts (grow/shrink/drop), transform incl. the collapse case, snapshot round-trip, xlsx round-trip.
- TS: workbookState + transform mirrors (vitest, 86 tests green).
- E2E (`sheet_merge.spec.ts`, live 3/3): merge renders colspan/rowspan + hides covered cells + unmerge restores content; merge reaches a second client and survives reload; insert-row-above shifts the merge. All 31 sheet specs green.

## Out of scope

Selection auto-expansion to full merges on drag (Excel behavior) — navigation snapping covers the common path; merge-aware sort/fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)