### PR TITLE
feat(sheet): CSV export of the active sheet

### DIFF
--- a/ui/src/js/sheet/sheetClipboard.test.ts
+++ b/ui/src/js/sheet/sheetClipboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rangeToTSV, parseTSV, pasteOps, fillOps, adjustFormula } from './sheetClipboard';
+import { rangeToTSV, rangeToCSV, parseTSV, pasteOps, fillOps, adjustFormula } from './sheetClipboard';
 
 const raw = (grid: Record<string, string>) => (r: number, c: number) => grid[`${r}:${c}`] ?? '';
 
@@ -23,6 +23,20 @@ describe('TSV clipboard', () => {
       { type: 'setCell', sheet: 's1', baseRev: 0, row: 3, col: 3, raw: 'c' },
       { type: 'setCell', sheet: 's1', baseRev: 0, row: 3, col: 4, raw: 'd' },
     ]);
+  });
+});
+
+describe('CSV export', () => {
+  it('rangeToCSV joins cols with comma, rows with CRLF', () => {
+    const sel = { anchor: { row: 0, col: 0 }, focus: { row: 1, col: 1 } };
+    const g = raw({ '0:0': 'a', '0:1': 'b', '1:0': 'c', '1:1': 'd' });
+    expect(rangeToCSV(sel, g)).toBe('a,b\r\nc,d');
+  });
+
+  it('quotes fields containing comma, quote, CR or LF and doubles quotes', () => {
+    const sel = { anchor: { row: 0, col: 0 }, focus: { row: 0, col: 3 } };
+    const g = raw({ '0:0': 'a,b', '0:1': 'say "hi"', '0:2': 'line1\nline2', '0:3': 'plain' });
+    expect(rangeToCSV(sel, g)).toBe('"a,b","say ""hi""","line1\nline2",plain');
   });
 });
 

--- a/ui/src/js/sheet/sheetClipboard.ts
+++ b/ui/src/js/sheet/sheetClipboard.ts
@@ -16,6 +16,21 @@ export function rangeToTSV(sel: Selection, rawAt: (r: number, c: number) => stri
   return rows.join('\n');
 }
 
+// rangeToCSV serializes a range as RFC-4180 CSV: a field is quoted only when it
+// contains a comma, quote, CR or LF, and embedded quotes are doubled. Rows are
+// joined with CRLF, which every spreadsheet app accepts.
+export function rangeToCSV(sel: Selection, valueAt: (r: number, c: number) => string): string {
+  const { r0, c0, r1, c1 } = normalize(sel);
+  const esc = (v: string): string => (/[",\r\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  const rows: string[] = [];
+  for (let r = r0; r <= r1; r++) {
+    const cols: string[] = [];
+    for (let c = c0; c <= c1; c++) cols.push(esc(valueAt(r, c)));
+    rows.push(cols.join(','));
+  }
+  return rows.join('\r\n');
+}
+
 export function parseTSV(text: string): string[][] {
   const trimmed = text.replace(/\r/g, '').replace(/\n$/, '');
   return trimmed.split('\n').map((line) => line.split('\t'));

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -4,7 +4,7 @@ import { SheetCollabClient } from './sheetCollabClient';
 import { FormulaEngine } from './formulaEngine';
 import { DomSheetView } from './sheetView';
 import { SheetPresence, effectiveCells, type PresenceFrame } from './sheetPresence';
-import { rangeToTSV, parseTSV, pasteOps, fillOps } from './sheetClipboard';
+import { rangeToTSV, rangeToCSV, parseTSV, pasteOps, fillOps } from './sheetClipboard';
 import { normalize, selCells, selIsSingle, type Selection } from './sheetSelection';
 import { createToolbar } from './sheetToolbar';
 import { createSheetTabs } from './sheetTabs';
@@ -305,6 +305,28 @@ export function startSheetEditor(root: HTMLElement): void {
         document.body.appendChild(a);
         a.click();
         a.remove();
+      },
+      exportCsv: () => {
+        // Client-side: serialize the active sheet's used range with computed
+        // values (what the user sees), then download. No websocket-killing nav.
+        const cells = cellsOfActive();
+        let maxRow = 0;
+        let maxCol = 0;
+        for (const { row, col, raw } of cells) {
+          if (raw === '') continue;
+          if (row > maxRow) maxRow = row;
+          if (col > maxCol) maxCol = col;
+        }
+        const sel = { anchor: { row: 0, col: 0 }, focus: { row: maxRow, col: maxCol } };
+        const csv = rangeToCSV(sel, displayValue);
+        const name = collab?.display.sheetById(activeSheetId)?.name || 'sheet';
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }));
+        a.download = `${name}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(a.href);
       },
       importXlsx: (file: File) => {
         const body = new FormData();

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -19,6 +19,8 @@ export interface ToolbarCallbacks {
   // Ribbon: workbook import/export (server round-trip).
   importXlsx?: (file: File) => void;
   exportXlsx?: () => void;
+  // Ribbon: client-side CSV export of the active sheet (no server round-trip).
+  exportCsv?: () => void;
   // Ribbon: clipboard + quick aggregation (wired by the editor).
   clipboardAction?: (a: 'cut' | 'copy' | 'paste') => void;
   autoSum?: () => void;
@@ -144,6 +146,7 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   };
   if (cb.importXlsx) fileMenuItem('Import (.xlsx)', () => fileInput.click());
   if (cb.exportXlsx) fileMenuItem('Export (.xlsx)', () => cb.exportXlsx?.());
+  if (cb.exportCsv) fileMenuItem('Export (.csv)', () => cb.exportCsv?.());
   fileWrap.append(fileBtn, fileMenu);
   tabsEl.appendChild(fileWrap);
 


### PR DESCRIPTION
## What

Adds **File → Export (.csv)** to the spreadsheet, alongside the existing xlsx import/export.

## Why

xlsx export exists, but CSV is the universal lightweight format (opens anywhere, no Excel needed). This fills the obvious gap.

## How

- New pure `rangeToCSV` in `sheetClipboard.ts` — RFC-4180 quoting (quote only when a field has a comma/quote/CR/LF; embedded quotes doubled; CRLF row terminator). Colocated with the existing `rangeToTSV` serializer and unit-tested.
- Editor `exportCsv` callback serializes the active sheet's used range with **computed** values (what the user sees), then downloads a `Blob` — no server round-trip and no `location.href` navigation (which would kill the collab websocket, same reason as xlsx export).
- Toolbar exposes it as a File-menu item.

## Tests

- `sheetClipboard.test.ts`: comma/CRLF joining + quoting/escaping edge cases. `vitest run` green (11 tests).
- `vite build --mode sheet` builds clean; no new `tsc` errors from touched files.

Skipped an e2e download test — the only non-trivial logic is the serializer (unit-tested); the button→download path is thin glue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)