### PR TITLE
feat(sheet): CSV import of the active sheet

### DIFF
--- a/ui/src/js/sheet/sheetClipboard.test.ts
+++ b/ui/src/js/sheet/sheetClipboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rangeToTSV, rangeToCSV, parseTSV, pasteOps, fillOps, adjustFormula } from './sheetClipboard';
+import { rangeToTSV, rangeToCSV, parseTSV, parseCSV, pasteOps, fillOps, adjustFormula } from './sheetClipboard';
 
 const raw = (grid: Record<string, string>) => (r: number, c: number) => grid[`${r}:${c}`] ?? '';
 
@@ -37,6 +37,31 @@ describe('CSV export', () => {
     const sel = { anchor: { row: 0, col: 0 }, focus: { row: 0, col: 3 } };
     const g = raw({ '0:0': 'a,b', '0:1': 'say "hi"', '0:2': 'line1\nline2', '0:3': 'plain' });
     expect(rangeToCSV(sel, g)).toBe('"a,b","say ""hi""","line1\nline2",plain');
+  });
+});
+
+describe('CSV import', () => {
+  it('parseCSV splits fields/records and tolerates CRLF + one trailing newline', () => {
+    expect(parseCSV('a,b\r\nc,d\r\n')).toEqual([['a', 'b'], ['c', 'd']]);
+    expect(parseCSV('x')).toEqual([['x']]);
+    expect(parseCSV('')).toEqual([]);
+  });
+
+  it('unquotes fields, un-doubles quotes, and keeps commas/newlines inside quotes', () => {
+    expect(parseCSV('"a,b","say ""hi""","line1\nline2",plain')).toEqual([
+      ['a,b', 'say "hi"', 'line1\nline2', 'plain'],
+    ]);
+  });
+
+  it('preserves a trailing empty field and empty lines', () => {
+    expect(parseCSV('a,')).toEqual([['a', '']]);
+    expect(parseCSV('a\r\n\r\nb')).toEqual([['a'], [''], ['b']]);
+  });
+
+  it('round-trips with rangeToCSV', () => {
+    const sel = { anchor: { row: 0, col: 0 }, focus: { row: 1, col: 1 } };
+    const g = raw({ '0:0': 'a,b', '0:1': 'say "hi"', '1:0': 'line1\nline2', '1:1': 'plain' });
+    expect(parseCSV(rangeToCSV(sel, g))).toEqual([['a,b', 'say "hi"'], ['line1\nline2', 'plain']]);
   });
 });
 

--- a/ui/src/js/sheet/sheetClipboard.ts
+++ b/ui/src/js/sheet/sheetClipboard.ts
@@ -31,6 +31,32 @@ export function rangeToCSV(sel: Selection, valueAt: (r: number, c: number) => st
   return rows.join('\r\n');
 }
 
+// parseCSV is an RFC-4180 reader: comma-separated fields, CRLF or LF records,
+// double-quoted fields that may contain commas/newlines, and "" for a literal
+// quote inside a quoted field. A single trailing newline yields no empty row.
+export function parseCSV(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++; } // escaped quote
+        else inQuotes = false;
+      } else field += ch;
+      continue;
+    }
+    if (ch === '"') inQuotes = true;
+    else if (ch === ',') { row.push(field); field = ''; }
+    else if (ch === '\n') { row.push(field); rows.push(row); row = []; field = ''; }
+    else if (ch !== '\r') field += ch; // drop bare CR outside quotes (CRLF)
+  }
+  if (field !== '' || row.length > 0) { row.push(field); rows.push(row); }
+  return rows;
+}
+
 export function parseTSV(text: string): string[][] {
   const trimmed = text.replace(/\r/g, '').replace(/\n$/, '');
   return trimmed.split('\n').map((line) => line.split('\t'));

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -4,7 +4,7 @@ import { SheetCollabClient } from './sheetCollabClient';
 import { FormulaEngine } from './formulaEngine';
 import { DomSheetView } from './sheetView';
 import { SheetPresence, effectiveCells, type PresenceFrame } from './sheetPresence';
-import { rangeToTSV, rangeToCSV, parseTSV, pasteOps, fillOps } from './sheetClipboard';
+import { rangeToTSV, rangeToCSV, parseTSV, parseCSV, pasteOps, fillOps } from './sheetClipboard';
 import { normalize, selCells, selIsSingle, type Selection } from './sheetSelection';
 import { createToolbar } from './sheetToolbar';
 import { createSheetTabs } from './sheetTabs';
@@ -327,6 +327,25 @@ export function startSheetEditor(root: HTMLElement): void {
         a.click();
         a.remove();
         URL.revokeObjectURL(a.href);
+      },
+      importCsv: (file: File) => {
+        if (readOnly || !collab) return;
+        blurActiveCell();
+        void file.text().then((text) => {
+          if (!collab) return;
+          const grid = parseCSV(text);
+          // Replace semantics (like xlsx import): clear the current used range,
+          // then lay the parsed grid down from A1.
+          let maxRow = 0;
+          let maxCol = 0;
+          for (const { row, col, raw } of cellsOfActive()) {
+            if (raw === '') continue;
+            if (row > maxRow) maxRow = row;
+            if (col > maxCol) maxCol = col;
+          }
+          collab.applyLocal({ type: 'clearRange', sheet: activeSheetId, baseRev: collab.rev, row: 0, col: 0, endRow: maxRow, endCol: maxCol });
+          for (const op of pasteOps(grid, { row: 0, col: 0 }, activeSheetId, collab.rev)) collab.applyLocal(op);
+        });
       },
       importXlsx: (file: File) => {
         const body = new FormData();

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -19,8 +19,9 @@ export interface ToolbarCallbacks {
   // Ribbon: workbook import/export (server round-trip).
   importXlsx?: (file: File) => void;
   exportXlsx?: () => void;
-  // Ribbon: client-side CSV export of the active sheet (no server round-trip).
+  // Ribbon: client-side CSV export/import of the active sheet (no server round-trip).
   exportCsv?: () => void;
+  importCsv?: (file: File) => void;
   // Ribbon: clipboard + quick aggregation (wired by the editor).
   clipboardAction?: (a: 'cut' | 'copy' | 'paste') => void;
   autoSum?: () => void;
@@ -116,6 +117,18 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   });
   bar.appendChild(fileInput);
 
+  // Separate hidden .csv input (client-side import, replaces the active sheet).
+  const csvInput = document.createElement('input');
+  csvInput.type = 'file';
+  csvInput.accept = '.csv,text/csv';
+  csvInput.style.display = 'none';
+  csvInput.addEventListener('change', () => {
+    const f = csvInput.files?.[0];
+    if (f) cb.importCsv?.(f);
+    csvInput.value = '';
+  });
+  bar.appendChild(csvInput);
+
   // --- File tab: green, opens a dropdown menu instead of switching tabs ---
   const fileWrap = document.createElement('div');
   fileWrap.className = 'sheet-file-wrap';
@@ -147,6 +160,7 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   if (cb.importXlsx) fileMenuItem('Import (.xlsx)', () => fileInput.click());
   if (cb.exportXlsx) fileMenuItem('Export (.xlsx)', () => cb.exportXlsx?.());
   if (cb.exportCsv) fileMenuItem('Export (.csv)', () => cb.exportCsv?.());
+  if (cb.importCsv) fileMenuItem('Import (.csv)', () => csvInput.click());
   fileWrap.append(fileBtn, fileMenu);
   tabsEl.appendChild(fileWrap);
 


### PR DESCRIPTION
## What

Adds **File → Import (.csv)**, the counterpart to the CSV export (#361).

## How

- New pure `parseCSV` in `sheetClipboard.ts` — an RFC-4180 reader: comma fields, CRLF/LF records, double-quoted fields that may contain commas/newlines, `""` for a literal quote. A single trailing newline yields no empty row. Round-trips with `rangeToCSV`.
- Dedicated hidden `.csv` file input in the toolbar (separate from the shared `.xlsx` one).
- Editor `importCsv` uses **replace** semantics like the xlsx import: clear the current used range, then lay the parsed grid from A1 — all via local ops, no server round-trip.

## Tests

- `sheetClipboard.test.ts`: field/record splitting, CRLF + trailing newline, quote un-escaping, embedded commas/newlines, empty lines, and a `parseCSV(rangeToCSV(...))` round-trip. `vitest run` green (15 tests).
- `vite build --mode sheet` clean; no new `tsc` errors from touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)