### PR TITLE
feat(sheet): Min/Max in the status-bar stats

### DIFF
--- a/playwright/specs/sheet_excel_chrome.spec.ts
+++ b/playwright/specs/sheet_excel_chrome.spec.ts
@@ -104,7 +104,7 @@ test.describe('Sheet Excel chrome', () => {
     await expect(cell(page, 0, 0)).toHaveText('neu2');
   });
 
-  test('statusbar shows average, count, and sum for a numeric selection', async ({ page }) => {
+  test('statusbar shows average, count, min, max, and sum for a numeric selection', async ({ page }) => {
     const padId = `xl-stats-${Date.now()}`;
     await openSheet(page, padId);
     await commitCell(page, 0, 0, '1'); // A1
@@ -116,6 +116,8 @@ test.describe('Sheet Excel chrome', () => {
     const stats = page.locator('.sheet-statusbar .sheet-stats');
     await expect(stats).toContainText('Average: 2');
     await expect(stats).toContainText('Count: 3');
+    await expect(stats).toContainText('Min: 1');
+    await expect(stats).toContainText('Max: 3');
     await expect(stats).toContainText('Sum: 6');
   });
 

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -137,6 +137,8 @@ export function startSheetEditor(root: HTMLElement): void {
     let sum = 0;
     let numCount = 0;
     let count = 0;
+    let min = Infinity;
+    let max = -Infinity;
     for (const { row, col } of selCells(selection)) {
       const raw = rawValue(row, col);
       if (raw === '') continue;
@@ -146,13 +148,16 @@ export function startSheetEditor(root: HTMLElement): void {
       if (value.trim() !== '' && Number.isFinite(n)) {
         sum += n;
         numCount++;
+        if (n < min) min = n;
+        if (n > max) max = n;
       }
     }
     if (numCount === 0) return;
     // toPrecision(12) strips float noise (0.1+0.2 -> 0.3) without truncating
     // typical spreadsheet magnitudes.
     const f = (n: number): string => String(parseFloat(n.toPrecision(12)));
-    for (const part of [`Average: ${f(sum / numCount)}`, `Count: ${count}`, `Sum: ${f(sum)}`]) {
+    // Excel status-bar order: Average, Count, Min, Max, Sum.
+    for (const part of [`Average: ${f(sum / numCount)}`, `Count: ${count}`, `Min: ${f(min)}`, `Max: ${f(max)}`, `Sum: ${f(sum)}`]) {
       const s = document.createElement('span');
       s.textContent = part;
       statsEl.appendChild(s);


### PR DESCRIPTION
## What

The spreadsheet status bar shows Average/Count/Sum for a numeric multi-cell selection. Excel also shows **Min** and **Max** — this adds them (order: Average, Count, Min, Max, Sum).

## How

Two extra accumulators in the existing single-pass `updateStats` scan; formula cells count with their computed value, same as the other stats. Same `numCount === 0` guard.

## Tests

Extended the existing `sheet_excel_chrome.spec.ts` status-bar test with `Min: 1` / `Max: 3` assertions. Ran locally against a live server — passes. Sheet bundle builds clean; no new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)