### PR TITLE
fix(sheet): Delete clears a single selected cell

### DIFF
--- a/playwright/specs/sheet_selection.spec.ts
+++ b/playwright/specs/sheet_selection.spec.ts
@@ -135,4 +135,26 @@ test.describe('Sheet selection, fill, and clipboard', () => {
       await expect(cell(page, 2, 1)).toHaveText('bar', { timeout: 10000 });
     });
   });
+
+  test('Delete clears a single selected cell', async ({ page }) => {
+    const padId = `sheet-del1-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'hallo'); // A1
+    await cell(page, 0, 0).click();
+    await page.keyboard.press('Delete');
+    await expect(cell(page, 0, 0)).toHaveText('');
+  });
+
+  test('Backspace in the formula bar edits the formula, not clears the cell', async ({ page }) => {
+    const padId = `sheet-fxbksp-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'abc'); // A1
+    await cell(page, 0, 0).click();
+    const fx = page.locator('.sheet-fx-input');
+    await fx.click();
+    await page.keyboard.press('Backspace'); // must act on fx text, not wipe A1
+    await page.keyboard.press('Escape'); // cancel the edit
+    // If the document Delete handler had fired, A1 would be empty regardless.
+    await expect(cell(page, 0, 0)).toHaveText('abc');
+  });
 });

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -573,7 +573,15 @@ export function startSheetEditor(root: HTMLElement): void {
       doPaste();
       return;
     }
-    if ((e.key === 'Delete' || e.key === 'Backspace') && !editingNow() && !readOnly && !selIsSingle(selection)) {
+    // Clear the selection (single cell or range), like Excel. The grid-focus
+    // guard replaces the old single-cell exclusion: it lets Delete clear one
+    // cell while still keeping Backspace working in the formula bar and any
+    // other input outside the grid (selection is single there too).
+    if (
+      (e.key === 'Delete' || e.key === 'Backspace') &&
+      !editingNow() && !readOnly &&
+      (e.target as HTMLElement | null)?.closest?.('.sheet-grid')
+    ) {
       e.preventDefault();
       blurActiveCell();
       const { r0, c0, r1, c1 } = normalize(selection);


### PR DESCRIPTION
## Problem

Delete/Backspace only cleared **multi-cell** selections (guarded by `!selIsSingle`). A single selected cell fell through to native `contenteditable`, which starts a messy in-place char edit instead of clearing — unlike Excel, where Delete clears the active cell.

## Fix

Replace the single-cell exclusion with a **grid-focus guard**: the clear fires only when the keydown target is inside `.sheet-grid`. This:
- enables single-cell clear (Excel parity), and
- keeps Backspace working in the **formula bar** and any other input outside the grid (selection is single there too, so the old guard was accidentally protecting it — this makes the protection explicit and correct).

## Tests (`sheet_selection.spec.ts`)

- `Delete clears a single selected cell` — type into A1, select it, press Delete, assert empty.
- `Backspace in the formula bar edits the formula, not clears the cell` — regression guard for the case the old code accidentally covered.

Both ran locally against a live server — pass. Sheet bundle builds clean; no new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)