### PR TITLE
feat(sheet): Ctrl+B/I/U toggle bold, italic, underline

### DIFF
--- a/playwright/specs/sheet_excel_chrome.spec.ts
+++ b/playwright/specs/sheet_excel_chrome.spec.ts
@@ -51,6 +51,24 @@ test.describe('Sheet Excel chrome', () => {
     await expect(cell(page, 0, 0)).toHaveCSS('font-size', /^26\.6/);
   });
 
+  test('Ctrl+B/I/U toggle bold, italic, underline on the selection', async ({ page }) => {
+    const padId = `xl-fmtkeys-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'x'); // A1
+    await cell(page, 0, 0).click();
+
+    await page.keyboard.press('Control+b');
+    await expect(cell(page, 0, 0)).toHaveCSS('font-weight', /700|bold/);
+    await page.keyboard.press('Control+i');
+    await expect(cell(page, 0, 0)).toHaveCSS('font-style', 'italic');
+    await page.keyboard.press('Control+u');
+    await expect(cell(page, 0, 0)).toHaveCSS('text-decoration', /underline/);
+
+    // Ctrl+B again toggles bold back off.
+    await page.keyboard.press('Control+b');
+    await expect(cell(page, 0, 0)).toHaveCSS('font-weight', /400|normal/);
+  });
+
   test('wrap text switches the cell to normal white-space', async ({ page }) => {
     const padId = `xl-wrap-${Date.now()}`;
     await openSheet(page, padId);

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -573,6 +573,24 @@ export function startSheetEditor(root: HTMLElement): void {
       doPaste();
       return;
     }
+    // Ctrl/Cmd+B/I/U toggle the style on the selection, mirroring the ribbon's
+    // toggle buttons. Applying a style blurs the active cell, so the next
+    // shortcut arrives with focus on <body> — we must NOT require grid focus
+    // (that would break chaining B then I). Instead just skip real form fields
+    // so the formula bar keeps these keys. preventDefault stops the browser's
+    // contenteditable rich-text default on the focused cell.
+    const tag = (e.target as HTMLElement | null)?.tagName;
+    const inField = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+    if (mod && !editingNow() && !readOnly && !inField) {
+      const k = e.key.toLowerCase();
+      const styleKey = k === 'b' ? 'bold' : k === 'i' ? 'italic' : k === 'u' ? 'underline' : null;
+      if (styleKey) {
+        e.preventDefault();
+        const on = propsOf(selection.focus.row, selection.focus.col)[styleKey] === '1';
+        applyStyleToSelection({ [styleKey]: on ? '' : '1' });
+        return;
+      }
+    }
     // Clear the selection (single cell or range), like Excel. The grid-focus
     // guard replaces the old single-cell exclusion: it lets Delete clear one
     // cell while still keeping Backspace working in the formula bar and any


### PR DESCRIPTION
## What

Keyboard shortcuts **Ctrl/Cmd+B / +I / +U** to toggle bold, italic, underline on the current selection — mirroring the ribbon's existing toggle buttons.

## How

Added to the document keydown handler. Two deliberate guard choices:
- **Skip form fields** (`INPUT`/`TEXTAREA`/`SELECT`) so the formula bar keeps these keys — but do **not** require grid focus, because applying a style blurs the active cell; requiring focus would break chaining (press B, then I).
- **`preventDefault`** stops the browser's native `contenteditable` rich-text formatting on the focused cell.

Toggle reads the focus cell's prop (`bold`/`italic`/`underline` = `'1'`) and flips it via the same `applyStyleToSelection` the buttons use.

## Tests

- New `sheet_excel_chrome.spec.ts` test: B→bold, I→italic, U→underline, then B again → back to normal.
- Ran the full `sheet_excel_chrome` + `sheet_selection` specs locally (15 tests) — all pass, incl. the existing Delete/formula-bar tests (shared keydown handler, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)