### PR TITLE
feat(sheet): kollaboratives Undo/Redo

### DIFF
--- a/playwright/specs/sheet_excel_chrome.spec.ts
+++ b/playwright/specs/sheet_excel_chrome.spec.ts
@@ -159,6 +159,48 @@ test.describe('Sheet Excel chrome', () => {
     await ctx.close();
   });
 
+  test('undo and redo revert and reapply an edit', async ({ page }) => {
+    const padId = `xl-undo-${Date.now()}`;
+    await openSheet(page, padId);
+    // Typing into a cell appends to its content, so each value goes into a
+    // fresh cell — this test is about the history, not about cell editing.
+    await commitCell(page, 0, 0, 'first'); // A1
+    await commitCell(page, 1, 0, 'second'); // A2
+
+    // Toolbar path: undo the second edit, redo it.
+    await page.locator('.sheet-toolbar button[title="Undo (Ctrl+Z)"]').click();
+    await expect(cell(page, 1, 0)).toHaveText('');
+    await expect(cell(page, 0, 0)).toHaveText('first'); // the older edit stands
+    await page.locator('.sheet-toolbar button[title="Redo (Ctrl+Y)"]').click();
+    await expect(cell(page, 1, 0)).toHaveText('second');
+
+    // Keyboard path, stepping back through both edits.
+    await cell(page, 3, 3).click(); // focus a cell outside the edited ones
+    await page.keyboard.press('Control+z');
+    await expect(cell(page, 1, 0)).toHaveText('');
+    await page.keyboard.press('Control+z');
+    await expect(cell(page, 0, 0)).toHaveText('');
+    await page.keyboard.press('Control+y');
+    await expect(cell(page, 0, 0)).toHaveText('first');
+  });
+
+  test('undoing a multi-cell action reverts it in one step', async ({ page }) => {
+    const padId = `xl-undogroup-${Date.now()}`;
+    await openSheet(page, padId);
+    await commitCell(page, 0, 0, 'a'); // A1
+    await commitCell(page, 1, 0, 'b'); // A2
+
+    // Clear Contents writes one op per cell; undo must restore both at once.
+    await dragSelect(page, 0, 0, 1, 0);
+    await page.locator('.sheet-toolbar button[title="Clear"]').click();
+    await page.locator('.sheet-file-menu button', { hasText: 'Clear Contents' }).click();
+    await expect(cell(page, 0, 0)).toHaveText('');
+
+    await page.locator('.sheet-toolbar button[title="Undo (Ctrl+Z)"]').click();
+    await expect(cell(page, 0, 0)).toHaveText('a');
+    await expect(cell(page, 1, 0)).toHaveText('b');
+  });
+
   test('selected cell highlights its row and column headers', async ({ page }) => {
     const padId = `xl-headhl-${Date.now()}`;
     await openSheet(page, padId);

--- a/ui/src/js/sheet/sheetCollabClient.ts
+++ b/ui/src/js/sheet/sheetCollabClient.ts
@@ -1,6 +1,11 @@
 import type { Op } from './op';
 import { transform } from './transform';
+import { invertOp } from './undo';
 import { WorkbookState, type WorkbookSnapshot } from './workbookState';
+
+// Bounded so a long session cannot grow the history without limit; Excel caps
+// its own undo list too.
+const MAX_HISTORY = 100;
 
 // CollabTransport is the outbound channel for ops (wraps the socket emit).
 export interface CollabTransport {
@@ -27,6 +32,15 @@ export class SheetCollabClient {
   private committing = false;
   private transport: CollabTransport;
 
+  // Undo history. Each entry is the op list that reverts one user action; the
+  // ops are recorded per applyLocal but grouped per tick, so a multi-op action
+  // (paste, fill, styling a range) undoes in one step. Only local ops are ever
+  // recorded, so undo never touches another collaborator's work.
+  private undoStack: Op[][] = [];
+  private redoStack: Op[][] = [];
+  private group: Op[] | null = null;
+  private mode: 'edit' | 'undo' | 'redo' = 'edit';
+
   constructor(snap: WorkbookSnapshot, head: number, transport: CollabTransport) {
     this.rev = head;
     this.serverWb = new WorkbookState();
@@ -42,10 +56,67 @@ export class SheetCollabClient {
 
   // applyLocal applies a local edit optimistically and schedules it for sending.
   applyLocal(op: Op): void {
+    // Computed against the pre-op display state — that is what the inverse has
+    // to restore.
+    const inverse = invertOp(this.display, op);
     this.pending.push(op);
     this.display.applyOp(op);
+    this.record(inverse);
     this.onChange();
     this.flush();
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  // undo/redo replay a recorded entry as ordinary local ops, which is what makes
+  // them collaboration-safe: they are transformed, sent and acked like any edit.
+  undo(): void {
+    this.replay(this.undoStack.pop(), 'undo');
+  }
+
+  redo(): void {
+    this.replay(this.redoStack.pop(), 'redo');
+  }
+
+  private replay(entry: Op[] | undefined, mode: 'undo' | 'redo'): void {
+    if (!entry) return;
+    this.mode = mode;
+    for (const op of entry) this.applyLocal({ ...op, baseRev: this.rev });
+    this.closeGroup(); // the entry is complete now; do not wait for the tick
+  }
+
+  // record collects the inverse ops of one tick into a single history entry.
+  // Prepending keeps them in reverse application order, so undoing a group
+  // reverts its last op first.
+  private record(inverse: Op[]): void {
+    if (inverse.length === 0) return;
+    if (this.group === null) {
+      this.group = [];
+      queueMicrotask(() => this.closeGroup());
+    }
+    this.group.unshift(...inverse);
+  }
+
+  private closeGroup(): void {
+    const entry = this.group;
+    this.group = null;
+    const mode = this.mode;
+    this.mode = 'edit';
+    if (!entry || entry.length === 0) return;
+    if (mode === 'undo') {
+      this.redoStack.push(entry);
+      return;
+    }
+    this.undoStack.push(entry);
+    if (this.undoStack.length > MAX_HISTORY) this.undoStack.shift();
+    // A fresh edit invalidates the redo branch; a redo keeps it.
+    if (mode === 'edit') this.redoStack.length = 0;
   }
 
   private flush(): void {
@@ -75,6 +146,11 @@ export class SheetCollabClient {
     this.serverWb.applyOp(remoteOp);
     this.rev = newRev;
     this.pending = this.pending.map((p) => transform(p, remoteOp));
+    // The history holds ops against the old coordinate space too: a remote row
+    // insert must move a recorded undo the same way it moves a pending op.
+    const rebase = (stack: Op[][]): Op[][] => stack.map((entry) => entry.map((o) => transform(o, remoteOp)));
+    this.undoStack = rebase(this.undoStack);
+    this.redoStack = rebase(this.redoStack);
     this.rebuildDisplay();
     this.onChange();
   }

--- a/ui/src/js/sheet/sheetEditor.ts
+++ b/ui/src/js/sheet/sheetEditor.ts
@@ -6,7 +6,7 @@ import { DomSheetView } from './sheetView';
 import { SheetPresence, effectiveCells, type PresenceFrame } from './sheetPresence';
 import { rangeToTSV, rangeToCSV, parseTSV, parseCSV, pasteOps, fillOps } from './sheetClipboard';
 import { normalize, selCells, selIsSingle, type Selection } from './sheetSelection';
-import { createToolbar, type ToolbarCallbacks } from './sheetToolbar';
+import { createToolbar, type ToolbarCallbacks, type ToolbarElement } from './sheetToolbar';
 import { createSheetTabs } from './sheetTabs';
 import { sortRangeOps, distinctValues, hiddenRowsForFilter } from './sheetSortFilter';
 import { createFormulaBar, type FormulaBarHandle } from './sheetFormulaBar';
@@ -73,6 +73,7 @@ export function startSheetEditor(root: HTMLElement): void {
   // Client-local filter state (per active sheet, reset on switch — not collaborative).
   let hiddenRows = new Set<number>();
   let tabs: { el: HTMLElement; refresh: () => void } | null = null;
+  let toolbarEl: ToolbarElement | null = null;
 
   const transport = {
     send: (op: Op) =>
@@ -233,6 +234,7 @@ export function startSheetEditor(root: HTMLElement): void {
     }
     view?.render();
     tabs?.refresh();
+    toolbarEl?.refreshHistory();
     if (formulaBar) {
       const { r0, c0, r1, c1 } = normalize(selection);
       formulaBar.setActive(rangeRefA1(r0, c0, r1, c1), rawValue(selection.focus.row, selection.focus.col));
@@ -389,6 +391,9 @@ export function startSheetEditor(root: HTMLElement): void {
         if (!readOnly) formulaBar?.beginFormula(`=${fn}(`);
       },
       fill: doFill,
+      undo: () => doHistory('undo'),
+      redo: () => doHistory('redo'),
+      history: () => ({ canUndo: collab?.canUndo() ?? false, canRedo: collab?.canRedo() ?? false }),
       clear: (what: 'all' | 'formats' | 'contents') => {
         if (readOnly || !collab) return;
         blurActiveCell();
@@ -436,6 +441,7 @@ export function startSheetEditor(root: HTMLElement): void {
       },
     };
     const toolbar = createToolbar(actions);
+    toolbarEl = toolbar;
     formulaBar = createFormulaBar({
       readOnly: data.readonly,
       getFunctionNames: () => engine.functionNames(),
@@ -644,6 +650,15 @@ export function startSheetEditor(root: HTMLElement): void {
       for (const op of pasteOps(grid, { row: r0, col: c0 }, activeSheetId, collab.rev)) collab.applyLocal(op);
     });
   };
+  // Undo/redo this client's own edits. Blur first so a half-typed cell does not
+  // get committed over the restored value by the blur handler.
+  const doHistory = (which: 'undo' | 'redo'): void => {
+    if (readOnly || !collab) return;
+    blurActiveCell();
+    if (which === 'undo') collab.undo();
+    else collab.redo();
+  };
+
   // Fill the selection from its first row (down) or first column (right).
   // fillOps adjusts relative references, so formulas fill like in Excel.
   const doFill = (dir: 'down' | 'right'): void => {
@@ -670,6 +685,21 @@ export function startSheetEditor(root: HTMLElement): void {
       e.preventDefault();
       doPaste();
       return;
+    }
+    // Ctrl+Z / Ctrl+Y (and Ctrl+Shift+Z) — only outside cell editing, where the
+    // browser's own text undo still owns the keystroke.
+    if (mod && !editingNow() && !readOnly) {
+      const k = e.key.toLowerCase();
+      if (k === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        doHistory('undo');
+        return;
+      }
+      if (k === 'y' || (k === 'z' && e.shiftKey)) {
+        e.preventDefault();
+        doHistory('redo');
+        return;
+      }
     }
     // Ctrl+D / Ctrl+R fill the selection from its first row / column, like Excel.
     if (mod && !editingNow() && !readOnly && (e.key === 'd' || e.key === 'D' || e.key === 'r' || e.key === 'R')) {

--- a/ui/src/js/sheet/sheetToolbar.ts
+++ b/ui/src/js/sheet/sheetToolbar.ts
@@ -33,6 +33,11 @@ export interface ToolbarCallbacks {
   clear?: (what: 'all' | 'formats' | 'contents') => void;
   // Ribbon: View toggles that only affect this client (never sent on the wire).
   viewOption?: (opt: 'gridlines' | 'headings' | 'zoom', value: boolean | number) => void;
+  // Undo/redo of this client's own edits. history() drives the button states;
+  // the editor calls the returned refresh() whenever the workbook changes.
+  undo?: () => void;
+  redo?: () => void;
+  history?: () => { canUndo: boolean; canRedo: boolean };
   // Merge/unmerge the current selection (the editor decides which).
   mergeToggle?: () => void;
 }
@@ -100,9 +105,15 @@ const IC = {
   fillDown: '<rect x="3.5" y="1.5" width="9" height="3.5"/><path d="M8 6.5V13M5.5 10.5 8 13l2.5-2.5"/>',
   fillRight: '<rect x="1.5" y="3.5" width="3.5" height="9"/><path d="M6.5 8H13M10.5 5.5 13 8l-2.5 2.5"/>',
   clear: '<path d="M3 13h10"/><path d="m5.5 10.5 6-6a1.5 1.5 0 0 0-2-2l-6 6z"/><path d="M9 3.5 12.5 7"/>',
+  undo: '<path d="M3 8h7a3.5 3.5 0 0 1 0 7H6"/><path d="M5.5 5 2.5 8l3 3"/>',
+  redo: '<path d="M13 8H6a3.5 3.5 0 0 0 0 7h4"/><path d="M10.5 5l3 3-3 3"/>',
 };
 
-export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
+// The returned element carries refreshHistory(): the editor calls it after every
+// workbook change so the undo/redo buttons show whether there is anything left.
+export type ToolbarElement = HTMLElement & { refreshHistory: () => void };
+
+export function createToolbar(cb: ToolbarCallbacks): ToolbarElement {
   if (!document.getElementById('sheet-toolbar-style')) {
     const s = document.createElement('style');
     s.id = 'sheet-toolbar-style';
@@ -283,6 +294,22 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
     b.dataset.key = key;
     return b;
   };
+
+  // --- Home: Undo (Excel keeps these in the quick-access bar; same actions) ---
+  let refreshHistory = (): void => {};
+  if (cb.undo && cb.redo) {
+    const hist = row(group('Home', 'Undo'));
+    const undoBtn = btn(hist, { icon: IC.undo }, 'Undo (Ctrl+Z)', () => cb.undo?.());
+    const redoBtn = btn(hist, { icon: IC.redo }, 'Redo (Ctrl+Y)', () => cb.redo?.());
+    refreshHistory = () => {
+      const state = cb.history?.() ?? { canUndo: false, canRedo: false };
+      undoBtn.disabled = !state.canUndo;
+      redoBtn.disabled = !state.canRedo;
+      undoBtn.style.opacity = state.canUndo ? '' : '0.4';
+      redoBtn.style.opacity = state.canRedo ? '' : '0.4';
+    };
+    refreshHistory();
+  }
 
   // --- Home: Clipboard ---
   if (cb.clipboardAction) {
@@ -541,5 +568,5 @@ export function createToolbar(cb: ToolbarCallbacks): HTMLElement {
   }
 
   selectTab('Home');
-  return bar;
+  return Object.assign(bar, { refreshHistory: () => refreshHistory() });
 }

--- a/ui/src/js/sheet/undo.test.ts
+++ b/ui/src/js/sheet/undo.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WorkbookState } from './workbookState';
+import { invertOp } from './undo';
+import { SheetCollabClient } from './sheetCollabClient';
+import type { Op } from './op';
+
+let wb: WorkbookState;
+beforeEach(() => {
+  wb = new WorkbookState();
+  wb.addSheet('s1', 'Sheet1');
+});
+
+// A comparable fingerprint of everything applyOp can change, so "the inverse
+// restored the state" is checked structurally instead of field by field.
+const snapshot = (state: WorkbookState): string =>
+  JSON.stringify(
+    state.sheets.map((s) => ({
+      id: s.id,
+      name: s.name,
+      cells: [...s.cells.entries()]
+        .map(([k, c]) => [k, c.raw, state.styles.get(c.styleId ?? 0) ?? {}])
+        .sort((a, b) => String(a[0]).localeCompare(String(b[0]))),
+      colWidths: [...s.colWidths.entries()].sort((a, b) => a[0] - b[0]),
+      rowHeights: [...s.rowHeights.entries()].sort((a, b) => a[0] - b[0]),
+      frozen: [s.frozenRows, s.frozenCols],
+      merges: [...s.merges.entries()].sort((a, b) => a[0].localeCompare(b[0])),
+    })),
+  );
+
+// roundTrip applies `op`, then its inverse, and asserts the state is back.
+const roundTrip = (op: Op): void => {
+  const before = snapshot(wb);
+  const inverse = invertOp(wb, op);
+  wb.applyOp(op);
+  for (const inv of inverse) wb.applyOp(inv);
+  expect(snapshot(wb)).toBe(before);
+};
+
+const cell = (row: number, col: number, raw: string, props?: Record<string, string>): Op => ({
+  type: 'setCell', sheet: 's1', baseRev: 0, row, col, raw, props,
+});
+
+describe('invertOp', () => {
+  it('restores an overwritten cell, including its style', () => {
+    wb.applyOp(cell(1, 1, 'old', { bold: '1' }));
+    roundTrip(cell(1, 1, 'new', { italic: '1' }));
+    expect(wb.getCell('s1', 1, 1)?.raw).toBe('old');
+    expect(wb.getStyleProps('s1', 1, 1)).toEqual({ bold: '1' });
+  });
+
+  it('removes a cell that did not exist before', () => {
+    roundTrip(cell(2, 2, 'typed'));
+    expect(wb.getCell('s1', 2, 2)).toBeUndefined();
+  });
+
+  it('restores styling', () => {
+    wb.applyOp(cell(0, 0, 'x', { bold: '1' }));
+    roundTrip({ type: 'setStyle', sheet: 's1', baseRev: 0, row: 0, col: 0, props: { italic: '1', bg: '#ffcc00' } });
+    expect(wb.getStyleProps('s1', 0, 0)).toEqual({ bold: '1' });
+  });
+
+  it('restores every cell a clearRange wiped', () => {
+    wb.applyOp(cell(0, 0, 'a', { bold: '1' }));
+    wb.applyOp(cell(1, 1, 'b'));
+    wb.applyOp(cell(9, 9, 'outside'));
+    roundTrip({ type: 'clearRange', sheet: 's1', baseRev: 0, row: 0, col: 0, endRow: 2, endCol: 2 });
+    expect(wb.getCell('s1', 0, 0)?.raw).toBe('a');
+    expect(wb.getStyleProps('s1', 0, 0)).toEqual({ bold: '1' });
+    expect(wb.getCell('s1', 1, 1)?.raw).toBe('b');
+  });
+
+  it('undoes row and column inserts', () => {
+    wb.applyOp(cell(3, 0, 'keep'));
+    roundTrip({ type: 'insertRows', sheet: 's1', baseRev: 0, index: 1, count: 2 });
+    expect(wb.getCell('s1', 3, 0)?.raw).toBe('keep');
+    roundTrip({ type: 'insertCols', sheet: 's1', baseRev: 0, index: 0, count: 1 });
+  });
+
+  it('brings back deleted rows with their cells, sizes and merges', () => {
+    wb.applyOp(cell(2, 0, 'gone', { bold: '1' }));
+    wb.applyOp(cell(2, 1, 'gone2'));
+    wb.applyOp(cell(5, 0, 'shifts'));
+    wb.applyOp({ type: 'setDimension', sheet: 's1', baseRev: 0, axis: 'row', index: 2, size: 44 });
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 2, col: 2, endRow: 3, endCol: 3 });
+    roundTrip({ type: 'deleteRows', sheet: 's1', baseRev: 0, index: 2, count: 2 });
+    expect(wb.getCell('s1', 2, 0)?.raw).toBe('gone');
+    expect(wb.getStyleProps('s1', 2, 0)).toEqual({ bold: '1' });
+    expect(wb.getCell('s1', 5, 0)?.raw).toBe('shifts');
+    expect(wb.sheetById('s1')?.rowHeights.get(2)).toBe(44);
+    expect(wb.sheetById('s1')?.merges.get('2:2')).toEqual({ rows: 2, cols: 2 });
+  });
+
+  it('brings back deleted columns', () => {
+    wb.applyOp(cell(0, 1, 'gone'));
+    wb.applyOp({ type: 'setDimension', sheet: 's1', baseRev: 0, axis: 'col', index: 1, size: 150 });
+    roundTrip({ type: 'deleteCols', sheet: 's1', baseRev: 0, index: 1, count: 1 });
+    expect(wb.getCell('s1', 0, 1)?.raw).toBe('gone');
+    expect(wb.sheetById('s1')?.colWidths.get(1)).toBe(150);
+  });
+
+  it('undoes merge, including merges it absorbed, and unmerge', () => {
+    wb.applyOp({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 0, col: 0, endRow: 1, endCol: 1 });
+    roundTrip({ type: 'mergeCells', sheet: 's1', baseRev: 0, row: 0, col: 0, endRow: 3, endCol: 3 });
+    expect(wb.sheetById('s1')?.merges.get('0:0')).toEqual({ rows: 2, cols: 2 });
+    roundTrip({ type: 'unmergeCells', sheet: 's1', baseRev: 0, row: 0, col: 0, endRow: 3, endCol: 3 });
+    expect(wb.sheetById('s1')?.merges.get('0:0')).toEqual({ rows: 2, cols: 2 });
+  });
+
+  it('undoes dimensions, freeze and sheet-list ops', () => {
+    wb.applyOp({ type: 'setDimension', sheet: 's1', baseRev: 0, axis: 'col', index: 0, size: 120 });
+    roundTrip({ type: 'setDimension', sheet: 's1', baseRev: 0, axis: 'col', index: 0, size: 300 });
+    expect(wb.sheetById('s1')?.colWidths.get(0)).toBe(120);
+    // A first-ever resize has no previous size to restore, so the inverse writes
+    // the grid default (22px) instead of removing the entry — same rendering,
+    // just not a byte-identical state, hence no roundTrip() here.
+    const fresh: Op = { type: 'setDimension', sheet: 's1', baseRev: 0, axis: 'row', index: 4, size: 90 };
+    const inverse = invertOp(wb, fresh);
+    wb.applyOp(fresh);
+    for (const inv of inverse) wb.applyOp(inv);
+    expect(wb.sheetById('s1')?.rowHeights.get(4)).toBe(22);
+    wb.sheetById('s1')?.rowHeights.delete(4);
+    roundTrip({ type: 'setFreeze', sheet: 's1', baseRev: 0, frozenRows: 1, frozenCols: 1 });
+    roundTrip({ type: 'renameSheet', sheet: 's1', baseRev: 0, name: 'Renamed' });
+    roundTrip({ type: 'addSheet', sheet: 's2', baseRev: 0, name: 'Sheet2', index: 1 });
+  });
+
+  it('restores a deleted sheet with its contents', () => {
+    wb.applyOp({ type: 'addSheet', sheet: 's2', baseRev: 0, name: 'Data', index: 1 });
+    wb.applyOp({ type: 'setCell', sheet: 's2', baseRev: 0, row: 1, col: 1, raw: 'v', props: { bold: '1' } });
+    wb.applyOp({ type: 'mergeCells', sheet: 's2', baseRev: 0, row: 0, col: 0, endRow: 0, endCol: 2 });
+    roundTrip({ type: 'deleteSheet', sheet: 's2', baseRev: 0 });
+    expect(wb.getCell('s2', 1, 1)?.raw).toBe('v');
+    expect(wb.getStyleProps('s2', 1, 1)).toEqual({ bold: '1' });
+  });
+
+  it('undoing the refused deletion of the last sheet is a no-op', () => {
+    roundTrip({ type: 'deleteSheet', sheet: 's1', baseRev: 0 });
+    expect(wb.sheets).toHaveLength(1);
+  });
+});
+
+describe('SheetCollabClient undo/redo', () => {
+  const snap = { sheets: [{ id: 's1', name: 'Sheet1', cells: [] }] };
+  const client = (): SheetCollabClient => new SheetCollabClient(snap, 0, { send: () => {} });
+  const flushTick = (): Promise<void> => new Promise((r) => queueMicrotask(() => r()));
+
+  it('undoes and redoes a single edit', async () => {
+    const c = client();
+    c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: 0, col: 0, raw: 'hello' });
+    await flushTick();
+    expect(c.canUndo()).toBe(true);
+    c.undo();
+    expect(c.display.getCell('s1', 0, 0)).toBeUndefined();
+    expect(c.canRedo()).toBe(true);
+    c.redo();
+    expect(c.display.getCell('s1', 0, 0)?.raw).toBe('hello');
+    // Redoing pushes onto the undo stack again, so the step stays reversible.
+    c.undo();
+    expect(c.display.getCell('s1', 0, 0)).toBeUndefined();
+  });
+
+  it('treats ops applied in one tick as one undo step', async () => {
+    const c = client();
+    for (let i = 0; i < 3; i++) c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: i, col: 0, raw: `v${i}` });
+    await flushTick();
+    c.undo();
+    for (let i = 0; i < 3; i++) expect(c.display.getCell('s1', i, 0)).toBeUndefined();
+    expect(c.canUndo()).toBe(false);
+  });
+
+  it('keeps separate ticks as separate steps', async () => {
+    const c = client();
+    c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: 0, col: 0, raw: 'first' });
+    await flushTick();
+    c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: 0, col: 0, raw: 'second' });
+    await flushTick();
+    c.undo();
+    expect(c.display.getCell('s1', 0, 0)?.raw).toBe('first');
+    c.undo();
+    expect(c.display.getCell('s1', 0, 0)).toBeUndefined();
+  });
+
+  it('a new edit clears the redo branch', async () => {
+    const c = client();
+    c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: 0, col: 0, raw: 'a' });
+    await flushTick();
+    c.undo();
+    expect(c.canRedo()).toBe(true);
+    c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: 5, col: 5, raw: 'b' });
+    await flushTick();
+    expect(c.canRedo()).toBe(false);
+  });
+
+  it('rebases the history against remote structural ops', async () => {
+    const c = client();
+    c.applyLocal({ type: 'setCell', sheet: 's1', baseRev: 0, row: 3, col: 0, raw: 'mine' });
+    await flushTick();
+    c.onAccept(1);
+    // Somebody else inserts two rows above: my cell now lives at row 5, and the
+    // undo has to clear row 5, not row 3.
+    c.onRemote({ type: 'insertRows', sheet: 's1', baseRev: 1, index: 0, count: 2 }, 2);
+    expect(c.display.getCell('s1', 5, 0)?.raw).toBe('mine');
+    c.undo();
+    expect(c.display.getCell('s1', 5, 0)).toBeUndefined();
+    expect(c.display.getCell('s1', 3, 0)).toBeUndefined();
+  });
+
+  it('does not record remote ops', () => {
+    const c = client();
+    c.onRemote({ type: 'setCell', sheet: 's1', baseRev: 0, row: 0, col: 0, raw: 'theirs' }, 1);
+    expect(c.canUndo()).toBe(false);
+  });
+});

--- a/ui/src/js/sheet/undo.ts
+++ b/ui/src/js/sheet/undo.ts
@@ -1,0 +1,171 @@
+// invertOp builds the ops that undo `op`, read from the state *before* the op is
+// applied. Undo is therefore just more ops through the normal collaborative
+// pipeline: they get transformed against remote work and sent like any edit, so
+// undoing never rolls back what somebody else did in the meantime.
+//
+// Inverses carry `props`, never `styleId`: style ids are a client-local pool
+// index, only props travel on the wire.
+import type { Op } from './op';
+import type { SheetState, WorkbookState } from './workbookState';
+
+// Defaults the grid falls back to when a row/column has no explicit size. The
+// op vocabulary has no "unset dimension", so undoing the very first resize
+// restores the default instead of removing the entry.
+const DEFAULT_COL_WIDTH = 80;
+const DEFAULT_ROW_HEIGHT = 22;
+
+const parseKey = (k: string): [number, number] => {
+  const i = k.indexOf(':');
+  return [Number(k.slice(0, i)), Number(k.slice(i + 1))];
+};
+
+const base = (op: Op): Pick<Op, 'sheet' | 'baseRev'> => ({ sheet: op.sheet, baseRev: 0 });
+
+// cellRestore reproduces one cell exactly: raw content plus its style props.
+const cellRestore = (wb: WorkbookState, op: Op, sheet: SheetState, row: number, col: number): Op => {
+  const cell = sheet.cells.get(`${row}:${col}`);
+  return {
+    ...base(op),
+    type: 'setCell',
+    row,
+    col,
+    raw: cell?.raw ?? '',
+    props: { ...(wb.styles.get(cell?.styleId ?? 0) ?? {}) },
+  };
+};
+
+const mergeRestore = (op: Op, row: number, col: number, rows: number, cols: number): Op => ({
+  ...base(op),
+  type: 'mergeCells',
+  row,
+  col,
+  endRow: row + rows - 1,
+  endCol: col + cols - 1,
+});
+
+// bandRestore rebuilds everything a row/column deletion destroys: the cells in
+// the band, the sizes of the affected rows/columns, and the merges that the
+// shift dropped or resized.
+const bandRestore = (wb: WorkbookState, op: Op, sheet: SheetState, axis: 'row' | 'col', index: number, count: number): Op[] => {
+  const out: Op[] = [];
+  for (const [k] of sheet.cells) {
+    const [r, c] = parseKey(k);
+    const at = axis === 'row' ? r : c;
+    if (at >= index && at < index + count) out.push(cellRestore(wb, op, sheet, r, c));
+  }
+  const dims = axis === 'row' ? sheet.rowHeights : sheet.colWidths;
+  for (const [i, size] of dims) {
+    if (i >= index) out.push({ ...base(op), type: 'setDimension', axis, index: i, size });
+  }
+  for (const [k, sp] of sheet.merges) {
+    const [r, c] = parseKey(k);
+    const lo = axis === 'row' ? r : c;
+    const span = axis === 'row' ? sp.rows : sp.cols;
+    if (lo + span > index) out.push(mergeRestore(op, r, c, sp.rows, sp.cols));
+  }
+  return out;
+};
+
+export function invertOp(wb: WorkbookState, op: Op): Op[] {
+  switch (op.type) {
+    case 'addSheet':
+      return [{ ...base(op), type: 'deleteSheet' }];
+    case 'deleteSheet': {
+      const sheet = wb.sheetById(op.sheet);
+      // The last sheet is never actually deleted (applyOp refuses), so undoing
+      // it must not re-add anything either.
+      if (!sheet || wb.sheets.length <= 1) return [];
+      const out: Op[] = [
+        { ...base(op), type: 'addSheet', name: sheet.name, index: wb.sheets.indexOf(sheet) },
+      ];
+      for (const [k] of sheet.cells) {
+        const [r, c] = parseKey(k);
+        out.push(cellRestore(wb, op, sheet, r, c));
+      }
+      for (const [i, size] of sheet.colWidths) out.push({ ...base(op), type: 'setDimension', axis: 'col', index: i, size });
+      for (const [i, size] of sheet.rowHeights) out.push({ ...base(op), type: 'setDimension', axis: 'row', index: i, size });
+      for (const [k, sp] of sheet.merges) {
+        const [r, c] = parseKey(k);
+        out.push(mergeRestore(op, r, c, sp.rows, sp.cols));
+      }
+      if (sheet.frozenRows || sheet.frozenCols) {
+        out.push({ ...base(op), type: 'setFreeze', frozenRows: sheet.frozenRows, frozenCols: sheet.frozenCols });
+      }
+      return out;
+    }
+    case 'renameSheet': {
+      const sheet = wb.sheetById(op.sheet);
+      return sheet ? [{ ...base(op), type: 'renameSheet', name: sheet.name }] : [];
+    }
+    case 'moveSheet': {
+      const i = wb.sheets.findIndex((s) => s.id === op.sheet);
+      return i < 0 ? [] : [{ ...base(op), type: 'moveSheet', toIndex: i }];
+    }
+  }
+
+  const sheet = wb.sheetById(op.sheet);
+  if (!sheet) return [];
+  const row = op.row ?? 0;
+  const col = op.col ?? 0;
+  const index = op.index ?? 0;
+  const count = op.count ?? 0;
+
+  switch (op.type) {
+    case 'setCell':
+    case 'setStyle':
+      return [cellRestore(wb, op, sheet, row, col)];
+    case 'clearRange': {
+      const endRow = op.endRow ?? 0;
+      const endCol = op.endCol ?? 0;
+      const out: Op[] = [];
+      for (const [k] of sheet.cells) {
+        const [r, c] = parseKey(k);
+        if (r >= row && r <= endRow && c >= col && c <= endCol) out.push(cellRestore(wb, op, sheet, r, c));
+      }
+      return out;
+    }
+    case 'setDimension': {
+      const dims = op.axis === 'col' ? sheet.colWidths : sheet.rowHeights;
+      const previous = dims.get(index) ?? (op.axis === 'col' ? DEFAULT_COL_WIDTH : DEFAULT_ROW_HEIGHT);
+      return [{ ...base(op), type: 'setDimension', axis: op.axis, index, size: previous }];
+    }
+    case 'setFreeze':
+      return [{ ...base(op), type: 'setFreeze', frozenRows: sheet.frozenRows, frozenCols: sheet.frozenCols }];
+    case 'mergeCells': {
+      const endRow = op.endRow ?? 0;
+      const endCol = op.endCol ?? 0;
+      if (endRow === row && endCol === col) return []; // degenerate: applyOp ignores it
+      // Drop the new merge, then put back every merge it absorbed.
+      const out: Op[] = [{ ...base(op), type: 'unmergeCells', row, col, endRow, endCol }];
+      for (const [k, sp] of sheet.merges) {
+        const [r, c] = parseKey(k);
+        if (r <= endRow && r + sp.rows - 1 >= row && c <= endCol && c + sp.cols - 1 >= col) {
+          out.push(mergeRestore(op, r, c, sp.rows, sp.cols));
+        }
+      }
+      return out;
+    }
+    case 'unmergeCells': {
+      const endRow = op.endRow ?? 0;
+      const endCol = op.endCol ?? 0;
+      const out: Op[] = [];
+      for (const [k, sp] of sheet.merges) {
+        const [r, c] = parseKey(k);
+        if (r <= endRow && r + sp.rows - 1 >= row && c <= endCol && c + sp.cols - 1 >= col) {
+          out.push(mergeRestore(op, r, c, sp.rows, sp.cols));
+        }
+      }
+      return out;
+    }
+    case 'insertRows':
+      return [{ ...base(op), type: 'deleteRows', index, count }];
+    case 'insertCols':
+      return [{ ...base(op), type: 'deleteCols', index, count }];
+    case 'deleteRows':
+      return [{ ...base(op), type: 'insertRows', index, count }, ...bandRestore(wb, op, sheet, 'row', index, count)];
+    case 'deleteCols':
+      return [{ ...base(op), type: 'insertCols', index, count }, ...bandRestore(wb, op, sheet, 'col', index, count)];
+    default:
+      return [];
+  }
+}


### PR DESCRIPTION
## Ansatz

Undo rollt keinen Zustand zurück, sondern spielt **inverse Ops durch die normale Kollaborations-Pipeline**. Das ist der Punkt, an dem es unter Nebenläufigkeit korrekt bleibt:

1. Die Inverse wird gegen den Zustand *vor* der Op berechnet (in `applyLocal`, bevor sie angewandt wird).
2. Sie landet in einem clientlokalen Stack — nur eigene Ops, nie fremde.
3. Jede eintreffende Remote-Op transformiert den Stack genauso wie die pending Ops. Fügt jemand zwei Zeilen über meiner Zelle ein, löscht mein Undo danach Zeile 5 statt Zeile 3.
4. Beim Undo gehen die Inversen als ganz normale lokale Ops raus — Transformation, Ack und Broadcast wie bei jeder Bearbeitung.

Dadurch macht Undo nie die Arbeit eines anderen rückgängig, auch wenn sie zeitlich dazwischen liegt.

## invertOp

Deckt das gesamte Op-Vokabular ab:
- **Zellen und Stile** — mit `props`, nicht mit `styleId`: die Style-Id ist ein clientlokaler Pool-Index, über die Leitung gehen nur Props.
- **clearRange** — jede gelöschte Zelle inklusive Formatierung zurück.
- **Zeilen/Spalten einfügen und löschen** — beim Löschen werden Zellen, Größen und die vom Shift verworfenen bzw. gestauchten Merges wiederhergestellt.
- **Merges** — inklusive der Merges, die ein neuer Merge geschluckt hat.
- **Dimensionen, Freeze, Sheet-Liste** — ein gelöschtes Sheet kommt mit Inhalt, Größen, Merges und Freeze zurück.

## Gruppierung
Ops desselben Ticks bilden einen History-Eintrag. Paste, Ausfüllen oder das Formatieren eines Bereichs schreiben je eine Op pro Zelle und werden trotzdem in einem Schritt rückgängig gemacht — ohne Änderung an einer einzigen Aufrufstelle. History bei 100 Einträgen gedeckelt; eine neue Bearbeitung verwirft den Redo-Zweig, ein Redo behält ihn.

## UI
Undo/Redo im Home-Tab, ausgegraut wenn der jeweilige Stack leer ist, plus Ctrl+Z, Ctrl+Y und Ctrl+Shift+Z — nur außerhalb der Zellbearbeitung, drinnen gehört der Tastendruck dem Text-Undo des Browsers.

## Tests
17 neue Unit-Tests: pro Op-Typ ein Roundtrip gegen einen strukturellen State-Fingerprint (Zellen + aufgelöste Style-Props, Größen, Freeze, Merges), dazu Client-Tests für Gruppierung pro Tick, getrennte Ticks, Redo-Verwerfung, Rebase gegen eine fremde Zeileneinfügung und „Remote-Ops landen nicht in der History". Plus zwei Playwright-Tests (Button- und Tastaturpfad, Mehrzellen-Aktion in einem Schritt). Insgesamt 166 Vitest-Tests grün.

## Bekannte Grenze
Das Rückgängigmachen der allerersten Größenänderung einer Zeile/Spalte stellt den Grid-Default (80/22 px) her statt den Eintrag zu entfernen — das Op-Vokabular kennt kein „Dimension zurücksetzen". Optisch identisch, im State nicht bytegleich; im Test explizit festgehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)